### PR TITLE
Improving forceGC method on ActiveMQTestBase

### DIFF
--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -525,14 +525,15 @@ public abstract class ActiveMQTestBase extends Assert {
 
    public static void forceGC() {
       log.info("#test forceGC");
-      AtomicInteger finalized = new AtomicInteger(0);
+      CountDownLatch finalized = new CountDownLatch(1);
       WeakReference<DumbReference> dumbReference = new WeakReference<>(new DumbReference(finalized));
+
       // A loop that will wait GC, using the minimal time as possible
-      while (!(dumbReference.get() == null && finalized.get() == 1)) {
+      while (!(dumbReference.get() == null && finalized.getCount() == 0)) {
          System.gc();
          System.runFinalization();
          try {
-            Thread.sleep(100);
+            finalized.await(100, TimeUnit.MILLISECONDS);
          }
          catch (InterruptedException e) {
          }
@@ -2536,15 +2537,14 @@ public abstract class ActiveMQTestBase extends Assert {
 
    protected static class DumbReference {
 
-      private AtomicInteger finalized;
+      private CountDownLatch finalized;
 
-      public DumbReference(AtomicInteger finalized) {
+      public DumbReference(CountDownLatch finalized) {
          this.finalized = finalized;
       }
 
       public void finalize() throws Throwable {
-         System.out.println("FINALIZE");
-         finalized.incrementAndGet();
+         finalized.countDown();
          super.finalize();
       }
    }


### PR DESCRIPTION
(cherry picked from commit 15b8b81)

SessionCloseOnGCTest#testCloseOneSessionOnGC avoiding intermittent failure
(cherry picked from commit bd946d2)

SessionCloseOnGCTest#testCloseOneSessionOnGC avoiding intermittent failure - small improvement
(cherry picked from commit e35c4d5)

Small tweak on test
(cherry picked from commit 992c34b)

All these as part of https://issues.jboss.org/browse/JBEAP-1627