### PR TITLE
ARTEMIS-297 Handle Exceptions during server stop

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptor.java
@@ -66,11 +66,17 @@ public final class InVMAcceptor implements Acceptor {
 
    private final long connectionsAllowed;
 
-   public InVMAcceptor(final ClusterConnection clusterConnection,
+   private final String name;
+
+   public InVMAcceptor(final String name,
+                       final ClusterConnection clusterConnection,
                        final Map<String, Object> configuration,
                        final BufferHandler handler,
                        final ConnectionLifeCycleListener listener,
                        final Executor threadPool) {
+
+      this.name = name;
+
       this.clusterConnection = clusterConnection;
 
       this.configuration = configuration;
@@ -84,6 +90,10 @@ public final class InVMAcceptor implements Acceptor {
       executorFactory = new OrderedExecutorFactory(threadPool);
 
       connectionsAllowed = ConfigurationHelper.getLongProperty(TransportConstants.CONNECTIONS_ALLOWED, TransportConstants.DEFAULT_CONNECTIONS_ALLOWED, configuration);
+   }
+
+   public String getName() {
+      return name;
    }
 
    public Map<String, Object> getConfiguration() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
@@ -37,6 +37,6 @@ public class InVMAcceptorFactory implements AcceptorFactory {
                                   final Executor threadPool,
                                   final ScheduledExecutorService scheduledThreadPool,
                                   final Map<String, ProtocolManager> protocolHandler) {
-      return new InVMAcceptor(clusterConnection, configuration, handler, listener, threadPool);
+      return new InVMAcceptor(name, clusterConnection, configuration, handler, listener, threadPool);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -411,6 +411,10 @@ public class NettyAcceptor implements Acceptor {
       }
    }
 
+   public String getName() {
+      return name;
+   }
+
    /**
     * Transfers the Netty channel that has been created outside of this NettyAcceptor
     * to control it and configure it according to this NettyAcceptor setting.

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
@@ -347,7 +347,14 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
          if (ActiveMQServerLogger.LOGGER.isDebugEnabled()) {
             ActiveMQServerLogger.LOGGER.debug("Pausing acceptor " + acceptor);
          }
-         acceptor.pause();
+
+         try {
+            acceptor.pause();
+         }
+         catch (Throwable t) {
+            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor();
+         }
+
       }
 
       if (ActiveMQServerLogger.LOGGER.isDebugEnabled()) {
@@ -369,7 +376,12 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
       }
 
       for (Acceptor acceptor : acceptors.values()) {
-         acceptor.stop();
+         try {
+            acceptor.stop();
+         }
+         catch (Throwable t) {
+            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor();
+         }
       }
 
       acceptors.clear();
@@ -392,7 +404,6 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
       }
 
       started = false;
-
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/server/impl/RemotingServiceImpl.java
@@ -305,7 +305,7 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
             acceptor.pause();
          }
          catch (Exception e) {
-            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor();
+            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor(acceptor.getName());
          }
       }
    }
@@ -352,7 +352,7 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
             acceptor.pause();
          }
          catch (Throwable t) {
-            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor();
+            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor(acceptor.getName());
          }
 
       }
@@ -380,7 +380,7 @@ public class RemotingServiceImpl implements RemotingService, ConnectionLifeCycle
             acceptor.stop();
          }
          catch (Throwable t) {
-            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor();
+            ActiveMQServerLogger.LOGGER.errorStoppingAcceptor(acceptor.getName());
          }
       }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1283,8 +1283,8 @@ public interface ActiveMQServerLogger extends BasicLogger {
    void errorWritingToInvmConnector(@Cause Exception e, Runnable runnable);
 
    @LogMessage(level = Logger.Level.ERROR)
-   @Message(id = 224028, value = "Failed to stop acceptor", format = Message.Format.MESSAGE_FORMAT)
-   void errorStoppingAcceptor();
+   @Message(id = 224028, value = "Failed to stop accepto {0}r", format = Message.Format.MESSAGE_FORMAT)
+   void errorStoppingAcceptor(String name);
 
    @LogMessage(level = Logger.Level.ERROR)
    @Message(id = 224029, value = "large message sync: largeMessage instance is incompatible with it, ignoring data", format = Message.Format.MESSAGE_FORMAT)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1445,4 +1445,11 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @Message(id = 224066, value = "Duplicated Acceptor {0} with parameters {1} classFactory={2} duplicated on the configuration", format = Message.Format.MESSAGE_FORMAT)
    void duplicatedAcceptor(String name, String parameters, String classFactory);
 
+   @LogMessage(level = Logger.Level.ERROR)
+   @Message(id = 224068, value = "Unable to stop component: {0}", format = Message.Format.MESSAGE_FORMAT)
+   void errorStoppingComponent(@Cause Throwable t, String componentClassName);
+
+   @LogMessage(level = Logger.Level.DEBUG)
+   @Message(id = 224070, value = "Received Interrupt Exception whilst waiting for component to shutdown: {0}", format = Message.Format.MESSAGE_FORMAT)
+   void interruptWhilstStoppingComponent(String componentClassName);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -569,7 +569,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
     *
     * @param criticalIOError whether we have encountered an IO error with the journal etc
     */
-   void stop(boolean failoverOnServerShutdown, final boolean criticalIOError, boolean restarting) throws Exception {
+   void stop(boolean failoverOnServerShutdown, final boolean criticalIOError, boolean restarting) {
       synchronized (this) {
          if (state == SERVER_STATE.STOPPED || state == SERVER_STATE.STOPPING) {
             return;
@@ -584,7 +584,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          // aren't removed in case of failover
          if (groupingHandler != null) {
             managementService.removeNotificationListener(groupingHandler);
-            groupingHandler.stop();
+            stopComponent(groupingHandler);
          }
          stopComponent(clusterManager);
 
@@ -595,11 +595,16 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          // allows for graceful shutdown
          if (remotingService != null && configuration.isGracefulShutdownEnabled()) {
             long timeout = configuration.getGracefulShutdownTimeout();
-            if (timeout == -1) {
-               remotingService.getConnectionCountLatch().await();
+            try {
+               if (timeout == -1) {
+                  remotingService.getConnectionCountLatch().await();
+               }
+               else {
+                  remotingService.getConnectionCountLatch().await(timeout);
+               }
             }
-            else {
-               remotingService.getConnectionCountLatch().await(timeout);
+            catch (InterruptedException e) {
+               ActiveMQServerLogger.LOGGER.interruptWhilstStoppingComponent(remotingService.getClass().getName());
             }
          }
 
@@ -626,24 +631,45 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       callDeActiveCallbacks();
 
       stopComponent(backupManager);
-      activation.preStorageClose();
+
+      try {
+         activation.preStorageClose();
+      }
+      catch (Throwable t) {
+         ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, activation.getClass().getName());
+      }
+
       stopComponent(pagingManager);
 
       if (storageManager != null)
-         storageManager.stop(criticalIOError);
+         try {
+            storageManager.stop(criticalIOError);
+         }
+         catch (Throwable t) {
+            ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, storageManager.getClass().getName());
+         }
 
       // We stop remotingService before otherwise we may lock the system in case of a critical IO
       // error shutdown
       if (remotingService != null)
-         remotingService.stop(criticalIOError);
+         try {
+            remotingService.stop(criticalIOError);
+         }
+         catch (Throwable t) {
+            ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, remotingService.getClass().getName());
+         }
 
       // Stop the management service after the remoting service to ensure all acceptors are deregistered with JMX
       if (managementService != null)
-         managementService.unregisterServer();
+         try {
+            managementService.unregisterServer();
+         }
+         catch (Throwable t) {
+            ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, managementService.getClass().getName());
+         }
+
       stopComponent(managementService);
-
       stopComponent(resourceManager);
-
       stopComponent(postOffice);
 
       if (scheduledPool != null && !scheduledPoolSupplied) {
@@ -664,7 +690,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             }
          }
          catch (InterruptedException e) {
-            // Ignore
+            ActiveMQServerLogger.LOGGER.interruptWhilstStoppingComponent(threadPool.getClass().getName());
          }
       }
 
@@ -673,8 +699,15 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       if (!scheduledPoolSupplied)
          scheduledPool = null;
 
-      if (securityStore != null)
-         securityStore.stop();
+      if (securityStore != null) {
+         try {
+            securityStore.stop();
+         }
+         catch (Throwable t) {
+            ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, managementService.getClass().getName());
+         }
+      }
+
 
       pagingManager = null;
       securityStore = null;
@@ -696,11 +729,22 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       // to display in the log message
       SimpleString tempNodeID = getNodeID();
       if (activation != null) {
-         activation.close(failoverOnServerShutdown, restarting);
+         try {
+            activation.close(failoverOnServerShutdown, restarting);
+         }
+         catch (Throwable t) {
+            ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, activation.getClass().getName());
+         }
       }
-      if (backupActivationThread != null) {
 
-         backupActivationThread.join(30000);
+      if (backupActivationThread != null) {
+         try {
+            backupActivationThread.join(30000);
+         }
+         catch (InterruptedException e) {
+            ActiveMQServerLogger.LOGGER.interruptWhilstStoppingComponent(backupActivationThread.getClass().getName());
+         }
+
          if (backupActivationThread.isAlive()) {
             ActiveMQServerLogger.LOGGER.backupActivationDidntFinish(this);
             backupActivationThread.interrupt();
@@ -787,9 +831,15 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
    }
 
-   static void stopComponent(ActiveMQComponent component) throws Exception {
-      if (component != null)
-         component.stop();
+   static void stopComponent(ActiveMQComponent component) {
+      try {
+         if (component != null) {
+            component.stop();
+         }
+      }
+      catch (Throwable t) {
+         ActiveMQServerLogger.LOGGER.errorStoppingComponent(t, component.getClass().getName());
+      }
    }
 
    // ActiveMQServer implementation

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Acceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Acceptor.java
@@ -29,6 +29,10 @@ import org.apache.activemq.artemis.core.server.management.NotificationService;
  */
 public interface Acceptor extends ActiveMQComponent {
 
+   /** The name of the acceptor used on the configuration.
+    *  for logging and debug purposes. */
+   String getName();
+
    /**
     * Pause the acceptor and stop it from receiving client requests.
     */

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/AcceptorsTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/AcceptorsTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.unit.core.remoting.server.impl.fake.FakeAcceptorFactory;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class AcceptorsTest extends ActiveMQTestBase {
    @Test
    public void testMultipleAcceptorsWithSameHostPortDifferentName() throws Exception
    {
-      final String acceptorFactoryClass = "org.apache.activemq.artemis.tests.unit.core.remoting.server.impl.fake.FakeAcceptorFactory";
+      final String acceptorFactoryClass = FakeAcceptorFactory.class.getName();
 
       Map<String, Object> params = new HashMap<>();
       params.put("host", "localhost");

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/server/impl/fake/FakeAcceptorFactory.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/server/impl/fake/FakeAcceptorFactory.java
@@ -47,6 +47,10 @@ public class FakeAcceptorFactory implements AcceptorFactory {
 
    private final class FakeAcceptor implements Acceptor {
 
+      public String getName() {
+         return "fake";
+      }
+
       @Override
       public void pause() {
 


### PR DESCRIPTION
Stopping the server should be able to handle exceptions thrown by
individual components.  Before this patch the stop method would throw
any raised exception and exit.  This can lead to partial shutdowns of
the server resulting in leaking threads.  This patch catches any
component exceptions and logs an appropriate error message, allowing the
server to properly shutdown.

(cherry picked from commit 046c3b19422c821136c36bf65f65e674e071a44f)

Conflicts:
	artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java