### PR TITLE
ARTEMIS-359 - test suite fix - IBM JDK 6/7/8 does not allow byteman a…

### DIFF
--- a/tests/extra-tests/pom.xml
+++ b/tests/extra-tests/pom.xml
@@ -219,6 +219,17 @@
       <plugins>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+               <execution>
+                  <goals>
+                     <goal>properties</goal>
+                  </goals>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin> 
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
             <executions>
                <execution>
@@ -272,6 +283,7 @@
                <!-- when upgrading this plugin from 2.4 to 2.18.1 <forkMode>once</forkMode> was replaced with these: -->
                <forkCount>1</forkCount>
                <reuseForks>true</reuseForks>
+
                <!--
                <debugForkedProcess>true</debugForkedProcess>
                -->
@@ -280,7 +292,11 @@
 
                <!--<argLine>${activemq-surefire-argline} -Dorg.jboss.byteman.verbose -Dorg.jboss.byteman.contrib.bmunit.verbose</argLine>-->
                <!-- '-noverify' is needed here to fix VerifyErrors on ScaleDownFailoverTest and ScaleDownFailureTest (and their subclasses). I got the tip from https://issues.jboss.org/browse/BYTEMAN-248. -->
-               <argLine>${activemq-surefire-argline} -noverify</argLine>
+               <argLine>${activemq-surefire-argline} -noverify -javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar}</argLine>
+               <systemPropertyVariables>
+                  <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
+                  <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>
+               </systemPropertyVariables>
             </configuration>
          </plugin>
       </plugins>


### PR DESCRIPTION
…gent to modify classes.

(cherry picked from commit fe9b95ed64821c6ed63564a0c0ba9792123823b3)

https://issues.jboss.org/browse/JBEAP-3168 - [Artemis Testsuite] IBM JDK does not allow to instrument classes