### PR TITLE
ARTEMIS-423 Do not set backup node as self

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/BackupTopologyListener.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/BackupTopologyListener.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.server.impl;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ClusterTopologyListener;
 import org.apache.activemq.artemis.api.core.client.TopologyMember;
 
@@ -28,12 +29,22 @@ final class BackupTopologyListener implements ClusterTopologyListener {
    private final String ownId;
    private static final int WAIT_TIMEOUT = 60;
 
-   public BackupTopologyListener(String ownId) {
+   // Transport configuration of this node
+   private final TransportConfiguration myTc;
+
+   public BackupTopologyListener(String ownId, TransportConfiguration nodeTransportConfig) {
       this.ownId = ownId;
+      this.myTc = nodeTransportConfig;
    }
 
    @Override
    public void nodeUP(TopologyMember topologyMember, boolean last) {
+
+      // If the backup is this node then ignore.
+      if (myTc.equals(topologyMember.getBackup())) {
+         return;
+      }
+
       final String nodeID = topologyMember.getNodeId();
 
       if (ownId.equals(nodeID) && topologyMember.getBackup() != null)

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingLiveActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingLiveActivation.java
@@ -165,7 +165,7 @@ public class SharedNothingLiveActivation extends LiveActivation {
                   //backupUpToDate = false;
 
                   if (isFailBackRequest && replicatedPolicy.isAllowAutoFailBack()) {
-                     BackupTopologyListener listener1 = new BackupTopologyListener(activeMQServer.getNodeID().toString());
+                     BackupTopologyListener listener1 = new BackupTopologyListener(activeMQServer.getNodeID().toString(), clusterConnection.getConnector());
                      clusterConnection.addClusterTopologyListener(listener1);
                      if (listener1.waitForBackup()) {
                         try {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.server.impl;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
@@ -191,6 +192,14 @@ public final class SharedStoreBackupActivation extends Activation {
    }
 
    private class FailbackChecker implements Runnable {
+
+      BackupTopologyListener backupListener;
+
+      FailbackChecker() {
+         TransportConfiguration connector = activeMQServer.getClusterManager().getDefaultConnection(null).getConnector();
+         backupListener = new BackupTopologyListener(activeMQServer.getNodeID().toString(), connector);
+         activeMQServer.getClusterManager().getDefaultConnection(null).addClusterTopologyListener(backupListener);
+      }
 
       private boolean restarting = false;
 


### PR DESCRIPTION
(cherry picked from commit 964b1457336d0edcff9b4fc132dc34b5f13f5228)

Fixes: https://issues.jboss.org/browse/JBEAP-3089

Conflicts:
	artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedStoreBackupActivation.java