### PR TITLE
ARTEMIS-385 clean-up factory on timeout

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -788,6 +788,9 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       // how the sendSubscription happens.
       // in case this ever changes.
       if (topology != null && !factory.waitForTopology(callTimeout, TimeUnit.MILLISECONDS)) {
+         if (factory != null) {
+            factory.cleanup();
+         }
          throw ActiveMQClientMessageBundle.BUNDLE.connectionTimedOutOnReceiveTopology(discoveryGroup);
       }
 


### PR DESCRIPTION
This restores a call to ClientSessionFactory#cleanup that appears to have been
mistakenly removed by a previous change related to this JIRA.

(cherry picked from commit b23046d5f7c958e8f38e86de12979d75c97c401a)

https://issues.jboss.org/browse/JBEAP-3635
