### PR TITLE
ARTEMIS-437 Large Message send should be interrupted during failover

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQInterruptedException.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ActiveMQInterruptedException.java
@@ -26,4 +26,8 @@ public final class ActiveMQInterruptedException extends RuntimeException {
    public ActiveMQInterruptedException(Throwable cause) {
       super(cause);
    }
+
+   public ActiveMQInterruptedException(String message) {
+      super(message);
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientMessageBundle.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientMessageBundle.java
@@ -22,6 +22,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQDisconnectedException;
 import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
 import org.apache.activemq.artemis.api.core.ActiveMQInterceptorRejectedPacketException;
 import org.apache.activemq.artemis.api.core.ActiveMQInternalErrorException;
+import org.apache.activemq.artemis.api.core.ActiveMQInterruptedException;
 import org.apache.activemq.artemis.api.core.ActiveMQLargeMessageException;
 import org.apache.activemq.artemis.api.core.ActiveMQLargeMessageInterruptedException;
 import org.apache.activemq.artemis.api.core.ActiveMQNotConnectedException;
@@ -227,4 +228,10 @@ public interface ActiveMQClientMessageBundle {
 
    @Message(id = 119060, value = "Large Message Transmission interrupted on consumer shutdown.")
    ActiveMQLargeMessageInterruptedException largeMessageInterrupted();
+
+   @Message(id = 119061, value = "Cannot send a packet while channel is failing over.")
+   IllegalStateException cannotSendPacketDuringFailover();
+
+   @Message(id = 119062, value = "Multi-packet transmission (e.g. Large Messages) interrupted because of a reconnection.")
+   ActiveMQInterruptedException packetTransmissionInterrupted();
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerCreditManagerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerCreditManagerImpl.java
@@ -27,9 +27,9 @@ public class ClientProducerCreditManagerImpl implements ClientProducerCreditMana
 
    public static final int MAX_UNREFERENCED_CREDITS_CACHE_SIZE = 1000;
 
-   private final Map<SimpleString, ClientProducerCredits> producerCredits = new LinkedHashMap<SimpleString, ClientProducerCredits>();
+   private final Map<SimpleString, ClientProducerCredits> producerCredits = new LinkedHashMap<>();
 
-   private final Map<SimpleString, ClientProducerCredits> unReferencedCredits = new LinkedHashMap<SimpleString, ClientProducerCredits>();
+   private final Map<SimpleString, ClientProducerCredits> unReferencedCredits = new LinkedHashMap<>();
 
    private final ClientSessionInternal session;
 
@@ -41,6 +41,7 @@ public class ClientProducerCreditManagerImpl implements ClientProducerCreditMana
       this.windowSize = windowSize;
    }
 
+   @Override
    public synchronized ClientProducerCredits getCredits(final SimpleString address,
                                                         final boolean anon,
                                                         SessionContext context) {
@@ -84,6 +85,7 @@ public class ClientProducerCreditManagerImpl implements ClientProducerCreditMana
       }
    }
 
+   @Override
    public synchronized void returnCredits(final SimpleString address) {
       ClientProducerCredits credits = producerCredits.get(address);
 
@@ -92,6 +94,7 @@ public class ClientProducerCreditManagerImpl implements ClientProducerCreditMana
       }
    }
 
+   @Override
    public synchronized void receiveCredits(final SimpleString address, final int credits) {
       ClientProducerCredits cr = producerCredits.get(address);
 
@@ -100,6 +103,7 @@ public class ClientProducerCreditManagerImpl implements ClientProducerCreditMana
       }
    }
 
+   @Override
    public synchronized void receiveFailCredits(final SimpleString address, int credits) {
       ClientProducerCredits cr = producerCredits.get(address);
 
@@ -108,12 +112,14 @@ public class ClientProducerCreditManagerImpl implements ClientProducerCreditMana
       }
    }
 
+   @Override
    public synchronized void reset() {
       for (ClientProducerCredits credits : producerCredits.values()) {
          credits.reset();
       }
    }
 
+   @Override
    public synchronized void close() {
       windowSize = -1;
 
@@ -126,10 +132,12 @@ public class ClientProducerCreditManagerImpl implements ClientProducerCreditMana
       unReferencedCredits.clear();
    }
 
+   @Override
    public synchronized int creditsMapSize() {
       return producerCredits.size();
    }
 
+   @Override
    public synchronized int unReferencedCreditsSize() {
       return unReferencedCredits.size();
    }
@@ -162,35 +170,45 @@ public class ClientProducerCreditManagerImpl implements ClientProducerCreditMana
 
       static ClientProducerCreditsNoFlowControl instance = new ClientProducerCreditsNoFlowControl();
 
-      public void acquireCredits(int credits) throws InterruptedException {
+      @Override
+      public void acquireCredits(int credits)  {
       }
 
+      @Override
       public void receiveCredits(int credits) {
       }
 
+      @Override
       public void receiveFailCredits(int credits) {
       }
 
+      @Override
       public boolean isBlocked() {
          return false;
       }
 
+      @Override
       public void init(SessionContext ctx) {
       }
 
+      @Override
       public void reset() {
       }
 
+      @Override
       public void close() {
       }
 
+      @Override
       public void incrementRefCount() {
       }
 
+      @Override
       public int decrementRefCount() {
          return 1;
       }
 
+      @Override
       public void releaseOutstanding() {
       }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerCredits.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerCredits.java
@@ -21,7 +21,7 @@ import org.apache.activemq.artemis.spi.core.remoting.SessionContext;
 
 public interface ClientProducerCredits {
 
-   void acquireCredits(int credits) throws InterruptedException, ActiveMQException;
+   void acquireCredits(int credits) throws ActiveMQException;
 
    void receiveCredits(int credits);
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/LargeMessageControllerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/LargeMessageControllerImpl.java
@@ -35,6 +35,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.ActiveMQInterruptedException;
+import org.apache.activemq.artemis.api.core.ActiveMQLargeMessageInterruptedException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
@@ -329,7 +330,19 @@ public class LargeMessageControllerImpl implements LargeMessageController {
       // once the exception is set, the controller is pretty much useless
       if (handledException != null) {
          if (handledException instanceof ActiveMQException) {
-            throw (ActiveMQException) handledException;
+            ActiveMQException nestedException;
+
+            // This is just to be user friendly and give the user a proper exception trace,
+            // instead to just where it was canceled.
+            if (handledException instanceof ActiveMQLargeMessageInterruptedException) {
+               nestedException = new ActiveMQLargeMessageInterruptedException(handledException.getMessage());
+            }
+            else {
+               nestedException = new ActiveMQException(((ActiveMQException) handledException).getType(), handledException.getMessage());
+            }
+            nestedException.initCause(handledException);
+
+            throw nestedException;
          }
          else {
             throw new ActiveMQException(ActiveMQExceptionType.LARGE_MESSAGE_ERROR_BODY, "Error on saving LargeMessageBufferImpl", handledException);

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/Channel.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/Channel.java
@@ -40,6 +40,13 @@ public interface Channel {
    long getID();
 
    /**
+    * This number increases every time the channel reconnects succesfully.
+    * This is used to guarantee the integrity of the channel on sequential commands such as large messages.
+    * @return
+    */
+   int getReconnectID();
+
+   /**
     * For protocol check
     */
    boolean supports(byte packetID);
@@ -52,6 +59,15 @@ public interface Channel {
     * successful
     */
    boolean send(Packet packet);
+
+   /**
+    * Sends a packet on this channel.
+    *
+    * @param packet the packet to send
+    * @return false if the packet was rejected by an outgoing interceptor; true if the send was
+    * successful
+    */
+   boolean send(Packet packet, final int reconnectID);
 
    /**
     * Sends a packet on this channel using batching algorithm if appropriate
@@ -81,6 +97,17 @@ public interface Channel {
     * @throws ActiveMQException if an error occurs during the send
     */
    Packet sendBlocking(Packet packet, byte expectedPacket) throws ActiveMQException;
+
+   /**
+    * Sends a packet on this channel and then blocks until a response is received or a timeout
+    * occurs.
+    *
+    * @param packet         the packet to send
+    * @param expectedPacket the packet being expected.
+    * @return the response
+    * @throws ActiveMQException if an error occurs during the send
+    */
+   Packet sendBlocking(Packet packet, int reconnectID, byte expectedPacket) throws ActiveMQException;
 
    /**
     * Sets the {@link org.apache.activemq.artemis.core.protocol.core.ChannelHandler} that this channel should

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
@@ -153,6 +153,10 @@ public class ActiveMQSessionContext extends SessionContext {
       }
    }
 
+   public int getReconnectID() {
+      return sessionChannel.getReconnectID();
+   }
+
    private final CommandConfirmationHandler confirmationHandler = new CommandConfirmationHandler() {
       public void commandConfirmed(final Packet packet) {
          if (packet.getType() == PacketImpl.SESS_SEND) {
@@ -390,16 +394,17 @@ public class ActiveMQSessionContext extends SessionContext {
                                     boolean sendBlocking,
                                     boolean lastChunk,
                                     byte[] chunk,
+                                    int reconnectID,
                                     SendAcknowledgementHandler messageHandler) throws ActiveMQException {
       final boolean requiresResponse = lastChunk && sendBlocking;
       final SessionSendContinuationMessage chunkPacket = new SessionSendContinuationMessage(msgI, chunk, !lastChunk, requiresResponse, messageBodySize, messageHandler);
 
       if (requiresResponse) {
          // When sending it blocking, only the last chunk will be blocking.
-         sessionChannel.sendBlocking(chunkPacket, PacketImpl.NULL_RESPONSE);
+         sessionChannel.sendBlocking(chunkPacket, reconnectID, PacketImpl.NULL_RESPONSE);
       }
       else {
-         sessionChannel.send(chunkPacket);
+         sessionChannel.send(chunkPacket, reconnectID);
       }
 
       return chunkPacket.getPacketSize();

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ChannelImpl.java
@@ -83,6 +83,9 @@ public final class ChannelImpl implements Channel {
 
    private volatile long id;
 
+   /** This is used in */
+   private final AtomicInteger reconnectID = new AtomicInteger(0);
+
    private ChannelHandler handler;
 
    private Packet response;
@@ -130,7 +133,7 @@ public final class ChannelImpl implements Channel {
       this.confWindowSize = confWindowSize;
 
       if (confWindowSize != -1) {
-         resendCache = new ConcurrentLinkedQueue<Packet>();
+         resendCache = new ConcurrentLinkedQueue<>();
       }
       else {
          resendCache = null;
@@ -139,6 +142,11 @@ public final class ChannelImpl implements Channel {
       this.interceptors = interceptors;
    }
 
+   public int getReconnectID() {
+      return reconnectID.get();
+   }
+
+   @Override
    public boolean supports(final byte packetType) {
       int version = connection.getClientVersion();
 
@@ -160,26 +168,32 @@ public final class ChannelImpl implements Channel {
       }
    }
 
+   @Override
    public long getID() {
       return id;
    }
 
+   @Override
    public int getLastConfirmedCommandID() {
       return lastConfirmedCommandID.get();
    }
 
+   @Override
    public Lock getLock() {
       return lock;
    }
 
+   @Override
    public int getConfirmationWindowSize() {
       return confWindowSize;
    }
 
+   @Override
    public void returnBlocking() {
       returnBlocking(null);
    }
 
+   @Override
    public void returnBlocking(Throwable cause) {
       lock.lock();
 
@@ -193,24 +207,32 @@ public final class ChannelImpl implements Channel {
       }
    }
 
+   @Override
    public boolean sendAndFlush(final Packet packet) {
-      return send(packet, true, false);
+      return send(packet, -1, true, false);
    }
 
+   @Override
    public boolean send(final Packet packet) {
-      return send(packet, false, false);
+      return send(packet, -1, false, false);
    }
 
+   public boolean send(Packet packet, final int reconnectID) {
+      return send(packet, reconnectID, false, false);
+   }
+
+   @Override
    public boolean sendBatched(final Packet packet) {
-      return send(packet, false, true);
+      return send(packet, -1, false, true);
    }
 
+   @Override
    public void setTransferring(boolean transferring) {
       this.transferring = transferring;
    }
 
    // This must never called by more than one thread concurrently
-   public boolean send(final Packet packet, final boolean flush, final boolean batch) {
+   private boolean send(final Packet packet, final int reconnectID, final boolean flush, final boolean batch) {
       if (invokeInterceptors(packet, interceptors, connection) != null) {
          return false;
       }
@@ -228,9 +250,15 @@ public final class ChannelImpl implements Channel {
 
          try {
             if (failingOver) {
-               // TODO - don't hardcode this timeout
                try {
-                  failoverCondition.await(10000, TimeUnit.MILLISECONDS);
+                  if (connection.getBlockingCallFailoverTimeout() < 0) {
+                     failoverCondition.await();
+                  }
+                  else {
+                     if (!failoverCondition.await(connection.getBlockingCallFailoverTimeout(), TimeUnit.MILLISECONDS)) {
+                        ActiveMQClientLogger.LOGGER.debug("timed-out waiting for fail-over condition on non-blocking send");
+                     }
+                  }
                }
                catch (InterruptedException e) {
                   throw new ActiveMQInterruptedException(e);
@@ -239,7 +267,7 @@ public final class ChannelImpl implements Channel {
 
             // Sanity check
             if (transferring) {
-               throw new IllegalStateException("Cannot send a packet while channel is doing failover");
+               throw ActiveMQClientMessageBundle.BUNDLE.cannotSendPacketDuringFailover();
             }
 
             if (resendCache != null && packet.isRequiresConfirmations()) {
@@ -254,6 +282,8 @@ public final class ChannelImpl implements Channel {
             ActiveMQClientLogger.LOGGER.trace("Writing buffer for channelID=" + id);
          }
 
+         checkReconnectID(reconnectID);
+
          // The actual send must be outside the lock, or with OIO transport, the write can block if the tcp
          // buffer is full, preventing any incoming buffers being handled and blocking failover
          connection.getTransportConnection().write(buffer, flush, batch);
@@ -262,12 +292,24 @@ public final class ChannelImpl implements Channel {
       }
    }
 
+   private void checkReconnectID(int reconnectID) {
+      if (reconnectID >= 0 && reconnectID != this.reconnectID.get()) {
+         throw ActiveMQClientMessageBundle.BUNDLE.packetTransmissionInterrupted();
+      }
+   }
+
+   @Override
+   public Packet sendBlocking(final Packet packet, byte expectedPacket) throws ActiveMQException {
+      return sendBlocking(packet, -1, expectedPacket);
+   }
+
    /**
     * Due to networking issues or server issues the server may take longer to answer than expected.. the client may timeout the call throwing an exception
     * and the client could eventually retry another call, but the server could then answer a previous command issuing a class-cast-exception.
     * The expectedPacket will be used to filter out undesirable packets that would belong to previous calls.
     */
-   public Packet sendBlocking(final Packet packet, byte expectedPacket) throws ActiveMQException {
+   @Override
+   public Packet sendBlocking(final Packet packet, final int reconnectID, byte expectedPacket) throws ActiveMQException {
       String interceptionResult = invokeInterceptors(packet, interceptors, connection);
 
       if (interceptionResult != null) {
@@ -302,7 +344,7 @@ public final class ChannelImpl implements Channel {
                   }
                   else {
                      if (!failoverCondition.await(connection.getBlockingCallFailoverTimeout(), TimeUnit.MILLISECONDS)) {
-                        ActiveMQClientLogger.LOGGER.debug("timed-out waiting for failover condition");
+                        ActiveMQClientLogger.LOGGER.debug("timed-out waiting for fail-over condition on blocking send");
                      }
                   }
                }
@@ -316,6 +358,8 @@ public final class ChannelImpl implements Channel {
             if (resendCache != null && packet.isRequiresConfirmations()) {
                addResendPacket(packet);
             }
+
+            checkReconnectID(reconnectID);
 
             connection.getTransportConnection().write(buffer, false, false);
 
@@ -402,6 +446,7 @@ public final class ChannelImpl implements Channel {
       return null;
    }
 
+   @Override
    public void setCommandConfirmationHandler(final CommandConfirmationHandler handler) {
       if (confWindowSize < 0) {
          final String msg = "You can't set confirmationHandler on a connection with confirmation-window-size < 0." + " Look at the documentation for more information.";
@@ -410,14 +455,17 @@ public final class ChannelImpl implements Channel {
       commandConfirmationHandler = handler;
    }
 
+   @Override
    public void setHandler(final ChannelHandler handler) {
       this.handler = handler;
    }
 
+   @Override
    public ChannelHandler getHandler() {
       return handler;
    }
 
+   @Override
    public void close() {
       if (closed) {
          return;
@@ -433,6 +481,7 @@ public final class ChannelImpl implements Channel {
       closed = true;
    }
 
+   @Override
    public void transferConnection(final CoreRemotingConnection newConnection) {
       // Needs to synchronize on the connection to make sure no packets from
       // the old connection get processed after transfer has occurred
@@ -451,6 +500,7 @@ public final class ChannelImpl implements Channel {
       }
    }
 
+   @Override
    public void replayCommands(final int otherLastConfirmedCommandID) {
       if (resendCache != null) {
          if (isTrace) {
@@ -464,14 +514,18 @@ public final class ChannelImpl implements Channel {
       }
    }
 
+   @Override
    public void lock() {
       lock.lock();
+
+      reconnectID.incrementAndGet();
 
       failingOver = true;
 
       lock.unlock();
    }
 
+   @Override
    public void unlock() {
       lock.lock();
 
@@ -482,11 +536,13 @@ public final class ChannelImpl implements Channel {
       lock.unlock();
    }
 
+   @Override
    public CoreRemotingConnection getConnection() {
       return connection;
    }
 
    // Needs to be synchronized since can be called by remoting service timer thread too for timeout flush
+   @Override
    public synchronized void flushConfirmations() {
       if (resendCache != null && receivedBytes != 0) {
          receivedBytes = 0;
@@ -503,6 +559,7 @@ public final class ChannelImpl implements Channel {
       }
    }
 
+   @Override
    public void confirm(final Packet packet) {
       if (resendCache != null && packet.isRequiresConfirmations()) {
          lastConfirmedCommandID.incrementAndGet();
@@ -525,6 +582,7 @@ public final class ChannelImpl implements Channel {
       }
    }
 
+   @Override
    public void clearCommands() {
       if (resendCache != null) {
          lastConfirmedCommandID.set(-1);
@@ -535,6 +593,7 @@ public final class ChannelImpl implements Channel {
       }
    }
 
+   @Override
    public void handlePacket(final Packet packet) {
       if (packet.getType() == PacketImpl.PACKETS_CONFIRMED) {
          if (resendCache != null) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/SessionContext.java
@@ -61,6 +61,8 @@ public abstract class SessionContext {
 
    public abstract void resetName(String name);
 
+   public abstract int getReconnectID();
+
    /**
     * it will eather reattach or reconnect, preferably reattaching it.
     *
@@ -145,6 +147,7 @@ public abstract class SessionContext {
                                              boolean sendBlocking,
                                              boolean lastChunk,
                                              byte[] chunk,
+                                             int reconnectID,
                                              SendAcknowledgementHandler messageHandler) throws ActiveMQException;
 
    public abstract void setSendAcknowledgementHandler(final SendAcknowledgementHandler handler);

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -610,6 +610,10 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
       }
    }
 
+   public ClientSessionFactory getSessionFactory() {
+      return sessionFactory;
+   }
+
    // Private --------------------------------------------------------------------------------------
 
    /**

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessageProducer.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessageProducer.java
@@ -35,6 +35,7 @@ import javax.jms.Topic;
 import javax.jms.TopicPublisher;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQInterruptedException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
@@ -475,6 +476,11 @@ public class ActiveMQMessageProducer implements MessageProducer, QueueSender, To
          else {
             clientProducer.send(address, coreMessage);
          }
+      }
+      catch (ActiveMQInterruptedException e) {
+         JMSException jmsException = new JMSException(e.getMessage());
+         jmsException.initCause(e);
+         throw jmsException;
       }
       catch (ActiveMQException e) {
          throw JMSExceptionHelper.convertFromActiveMQException(e);

--- a/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageOverReplicationTest.java
+++ b/tests/extra-tests/src/test/java/org/apache/activemq/artemis/tests/extras/byteman/LargeMessageOverReplicationTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.extras.byteman;
+
+import javax.jms.JMSException;
+import javax.jms.MapMessage;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.ReplicatedBackupUtils;
+import org.apache.activemq.artemis.tests.util.TransportConfigurationUtils;
+import org.apache.activemq.artemis.utils.ReusableLatch;
+import org.apache.qpid.transport.util.Logger;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(BMUnitRunner.class)
+public class LargeMessageOverReplicationTest extends ActiveMQTestBase {
+
+   public static int messageChunkCount = 0;
+
+   private static final ReusableLatch ruleFired = new ReusableLatch(1);
+   private static ActiveMQServer backupServer;
+   private static ActiveMQServer liveServer;
+
+
+   ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory("tcp://localhost:61616?minLargeMessageSize=10000&HA=true&retryInterval=100&reconnectAttempts=-1&producerWindowSize=10000");
+   ActiveMQConnection connection;
+   Session session;
+   Queue queue;
+   MessageProducer producer;
+
+
+   @Before
+   public void setUp() throws Exception {
+      super.setUp();
+      ruleFired.setCount(1);
+      messageChunkCount = 0;
+
+      TransportConfiguration liveConnector = TransportConfigurationUtils.getNettyConnector(true, 0);
+      TransportConfiguration liveAcceptor = TransportConfigurationUtils.getNettyAcceptor(true, 0);
+      TransportConfiguration backupConnector = TransportConfigurationUtils.getNettyConnector(false, 0);
+      TransportConfiguration backupAcceptor = TransportConfigurationUtils.getNettyAcceptor(false, 0);
+
+      Configuration backupConfig = createDefaultInVMConfig().setBindingsDirectory(getBindingsDir(0, true)).setJournalDirectory(getJournalDir(0, true)).setPagingDirectory(getPageDir(0, true)).setLargeMessagesDirectory(getLargeMessagesDir(0, true));
+
+      Configuration liveConfig = createDefaultInVMConfig();
+
+      ReplicatedBackupUtils.configureReplicationPair(backupConfig, backupConnector, backupAcceptor, liveConfig, liveConnector, liveAcceptor);
+
+      liveServer = createServer(liveConfig);
+      liveServer.getConfiguration().addQueueConfiguration(new CoreQueueConfiguration().setName("jms.queue.Queue").setAddress("jms.queue.Queue"));
+      liveServer.start();
+
+      waitForServerToStart(liveServer);
+
+      backupServer = createServer(backupConfig);
+      backupServer.start();
+
+      waitForServerToStart(backupServer);
+
+
+      // Just to make sure the expression worked
+      Assert.assertEquals(10000, factory.getMinLargeMessageSize());
+      Assert.assertEquals(10000, factory.getProducerWindowSize());
+      Assert.assertEquals(100, factory.getRetryInterval());
+      Assert.assertEquals(-1, factory.getReconnectAttempts());
+      Assert.assertTrue(factory.isHA());
+
+      connection = (ActiveMQConnection) factory.createConnection();
+
+      waitForRemoteBackup(connection.getSessionFactory(), 30);
+
+      session = connection.createSession(true, Session.SESSION_TRANSACTED);
+      queue = session.createQueue("jms.queue.Queue");
+      producer = session.createProducer(queue);
+
+   }
+
+   @After
+   public void stopServers() throws Exception {
+      if (connection != null) {
+         try {
+            connection.close();
+         }
+         catch (Exception e) {
+         }
+      }
+      if (backupServer != null) {
+         backupServer.stop();
+         backupServer = null;
+      }
+
+      if (liveServer != null) {
+         liveServer.stop();
+         liveServer = null;
+      }
+
+      backupServer = liveServer = null;
+   }
+
+    /*
+   * simple test to induce a potential race condition where the server's acceptors are active, but the server's
+   * state != STARTED
+   */
+   @Test
+   @BMRules(
+      rules = {@BMRule(
+         name = "InterruptSending",
+         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.ActiveMQSessionContext",
+         targetMethod = "sendLargeMessageChunk",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageOverReplicationTest.messageChunkSent();")})
+   public void testSendLargeMessage() throws Exception {
+
+      MapMessage message = createLargeMessage();
+
+      try {
+         producer.send(message);
+         Assert.fail("expected an exception");
+         //      session.commit();
+      }
+      catch (JMSException expected) {
+      }
+
+      session.rollback();
+
+      producer.send(message);
+      session.commit();
+
+      MessageConsumer consumer = session.createConsumer(queue);
+      connection.start();
+
+      MapMessage messageRec = (MapMessage) consumer.receive(5000);
+      Assert.assertNotNull(messageRec);
+
+      for (int i = 0; i < 10; i++) {
+         Assert.assertEquals(1024 * 1024, message.getBytes("test" + i).length);
+      }
+   }
+
+   @Test
+   @BMRules(
+      rules = {@BMRule(
+         name = "InterruptReceive",
+         targetClass = "org.apache.activemq.artemis.core.protocol.core.impl.CoreSessionCallback",
+         targetMethod = "sendLargeMessageContinuation",
+         targetLocation = "ENTRY",
+         action = "org.apache.activemq.artemis.tests.extras.byteman.LargeMessageOverReplicationTest.messageChunkReceived();")})
+   public void testReceiveLargeMessage() throws Exception {
+
+      MapMessage message = createLargeMessage();
+
+      producer.send(message);
+      session.commit();
+
+      MessageConsumer consumer = session.createConsumer(queue);
+      connection.start();
+
+      MapMessage messageRec = null;
+
+      try {
+         consumer.receive(5000);
+         Assert.fail("Expected a failure here");
+      }
+      catch (JMSException expected) {
+      }
+
+      session.rollback();
+
+      messageRec = (MapMessage) consumer.receive(5000);
+      Assert.assertNotNull(messageRec);
+      session.commit();
+
+      for (int i = 0; i < 10; i++) {
+         Assert.assertEquals(1024 * 1024, message.getBytes("test" + i).length);
+      }
+   }
+
+   public static void messageChunkReceived() {
+      messageChunkCount++;
+
+      if (messageChunkCount == 100) {
+         final CountDownLatch latch = new CountDownLatch(1);
+         new Thread() {
+            public void run() {
+               try {
+                  latch.countDown();
+                  liveServer.stop();
+               }
+               catch (Exception e) {
+                  e.printStackTrace();
+               }
+            }
+         }.start();
+         try {
+            // just to make sure it's about to be stopped
+            // avoiding bootstrapping the thread as a delay
+            latch.await(1, TimeUnit.MINUTES);
+         }
+         catch (Throwable ignored ) {
+         }
+      }
+   }
+
+   public static void messageChunkSent() {
+      messageChunkCount++;
+
+      try {
+         if (messageChunkCount == 10) {
+            liveServer.stop(true);
+
+            System.err.println("activating");
+            if (!backupServer.waitForActivation(1, TimeUnit.MINUTES)) {
+               Logger.get(LargeMessageOverReplicationTest.class).warn("Can't failover server");
+            }
+         }
+      }
+      catch (Exception e) {
+         e.printStackTrace();
+      }
+   }
+
+   private MapMessage createLargeMessage() throws JMSException {
+      MapMessage message = session.createMapMessage();
+
+      for (int i = 0; i < 10; i++) {
+         message.setBytes("test" + i, new byte[1024 * 1024]);
+      }
+      return message;
+   }
+
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/BackupSyncDelay.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/util/BackupSyncDelay.java
@@ -250,6 +250,21 @@ public class BackupSyncDelay implements Interceptor {
       }
 
       @Override
+      public int getReconnectID() {
+         return 0;
+      }
+
+      @Override
+      public boolean send(Packet packet, int reconnectID) {
+         return false;
+      }
+
+      @Override
+      public Packet sendBlocking(Packet packet, int reconnectID, byte expectedPacket) throws ActiveMQException {
+         return null;
+      }
+
+      @Override
       public void replayCommands(int lastConfirmedCommandID) {
          throw new UnsupportedOperationException();
       }


### PR DESCRIPTION
(cherry picked from commit 26fe21baa4fed54d369b7090732081d1546b9638)

ARTEMIS-432 client gets msg after session stop
(cherry picked from commit 196f0ca8d6b9e91f042481e3595105f29c3f01bd)

https://issues.jboss.org/browse/JBEAP-3273 &&
https://issues.jboss.org/browse/JBEAP-2315
