### PR TITLE
ARTEMIS-439 Set default global thread pool based on cores

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ActiveMQClient.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ActiveMQClient.java
@@ -118,7 +118,7 @@ public final class ActiveMQClient {
 
    public static final int DEFAULT_THREAD_POOL_MAX_SIZE = -1;
 
-   public static final int DEFAULT_GLOBAL_THREAD_POOL_MAX_SIZE = 500;
+   public static final int DEFAULT_GLOBAL_THREAD_POOL_MAX_SIZE = 8 * Runtime.getRuntime().availableProcessors();
 
    public static final int DEFAULT_SCHEDULED_THREAD_POOL_MAX_SIZE = 5;
 


### PR DESCRIPTION
Fixes: https://issues.jboss.org/browse/JBEAP-2947

(cherry picked from commit e9992bc59ff4c379a21245f0b56901e4fbc15348)
