### PR TITLE
ARTEMIS-482 testsuite fixes:

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnector.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMConnector.java
@@ -92,14 +92,14 @@ public class InVMConnector extends AbstractConnector {
 
    private static ExecutorService threadPoolExecutor;
 
-   public static void resetThreadPool() {
+   public static synchronized void resetThreadPool() {
       if (threadPoolExecutor != null) {
          threadPoolExecutor.shutdown();
          threadPoolExecutor = null;
       }
    }
 
-   private static ExecutorService getInVMExecutor() {
+   private static synchronized ExecutorService getInVMExecutor() {
       if (threadPoolExecutor == null) {
          if (ActiveMQClient.globalThreadMaxPoolSize <= -1) {
             threadPoolExecutor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(), Executors.defaultThreadFactory());

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/tests/util/ActiveMQTestBase.java
@@ -230,7 +230,6 @@ public abstract class ActiveMQTestBase extends Assert {
       closeAllServerLocatorsFactories();
 
       try {
-         assertAllExecutorsFinished();
          assertAllClientConsumersAreClosed();
          assertAllClientProducersAreClosed();
          assertAllClientSessionsAreClosed();
@@ -271,6 +270,7 @@ public abstract class ActiveMQTestBase extends Assert {
             s.shutdown();
          }
          InVMConnector.resetThreadPool();
+         assertAllExecutorsFinished();
 
 
          //clean up pools before failing


### PR DESCRIPTION
The new Executor operationr needs to be synchronized as a few tests are failing because of this
another fix on the test base class

(cherry picked from commit bd3d0492fd03978f14bb77427d02640af4a31dbd)

https://issues.jboss.org/browse/JBEAP-4203

*\* there is a class change but this mainly affects the testsuite as nothing will clear the InVMConnector's executor
