### PR TITLE
ARTEMIS-551 Obfuscate truststore password

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/TransportConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/TransportConfiguration.java
@@ -238,7 +238,7 @@ public class TransportConfiguration implements Serializable {
 
             // HORNETQ-1281 - don't log passwords
             String val;
-            if (key.equals(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME) || key.equals(TransportConstants.DEFAULT_TRUSTSTORE_PASSWORD)) {
+            if (key.equals(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME) || key.equals(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME)) {
                val = "****";
             }
             else {

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/TransportConfigurationTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/TransportConfigurationTest.java
@@ -19,8 +19,12 @@ package org.apache.activemq.artemis.api.core;
 
 import java.util.HashMap;
 
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 
 public class TransportConfigurationTest {
 
@@ -61,4 +65,16 @@ public class TransportConfigurationTest {
       Assert.assertNotEquals(configuration.hashCode(), configuration2.hashCode());
 
    }
+
+   @Test
+   public void testToStringObfuscatesPasswords() {
+      HashMap<String, Object> params = new HashMap<>();
+      params.put(TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME, "secret_password");
+      params.put(TransportConstants.KEYSTORE_PASSWORD_PROP_NAME, "secret_password");
+
+      TransportConfiguration configuration = new TransportConfiguration("SomeClass", params, null);
+
+      Assert.assertThat(configuration.toString(), not(containsString("secret_password")));
+   }
+
 }


### PR DESCRIPTION
Obfuscate truststore password in TransportConfiguration.toString()
in the same way as keystore. The password will not be logged in
plain text when bridge is connected.

https://issues.jboss.org/browse/JBEAP-4852 (pm_ack + and qa_ack +, missing devel_ack)
cherry-pick a fix from upstream master branch

upstream Artemis issue:  https://issues.apache.org/jira/browse/ARTEMIS-551 Resolved
upstream master branch PR: https://github.com/apache/activemq-artemis/pull/557 (merged)

downstream 6.4.x bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1339881 Verified
downstream HornetQ PR: https://github.com/hornetq/hornetq/pull/2094 (merged)
