### PR TITLE
[JBEAP-4854] java.util.MissingFormatArgumentException: Format specifier '%s' during backup activation

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PageSubscriptionImpl.java
@@ -554,11 +554,14 @@ final class PageSubscriptionImpl implements PageSubscription {
 
    @Override
    public boolean isComplete(long page) {
-      logger.tracef("%s isComplete %d", this, page);
+      if (empty && consumedPages.isEmpty()) {
+         logger.tracef("%s isComplete %d", this, page);
+      }
+
       synchronized (consumedPages) {
          if (empty && consumedPages.isEmpty()) {
             if (logger.isTraceEnabled()) {
-               logger.tracef("isComplete(%d)::Subscription %s has empty=%s, consumedPages.isEmpty=%s", (Object)page, this, consumedPages.isEmpty());
+               logger.tracef("isComplete(%d)::Subscription %s has empty=%s, consumedPages.isEmpty=%s", page, this, empty, consumedPages.isEmpty());
             }
             return true;
          }
@@ -566,11 +569,15 @@ final class PageSubscriptionImpl implements PageSubscription {
          PageCursorInfo info = consumedPages.get(page);
 
          if (info == null && empty) {
-            logger.tracef("isComplete(%d)::::Couldn't find info and it is empty", page);
+            if (empty && consumedPages.isEmpty()) {
+               logger.tracef("isComplete(%d)::::Couldn't find info and it is empty", page);
+            }
             return true;
          }
          else {
-            logger.tracef("isComplete(%d)::calling is %s", (Object)page, this, consumedPages.isEmpty());
+            if (empty && consumedPages.isEmpty()) {
+               logger.tracef("isComplete(%d)::calling is %s, consumedPages.isEmpty=%s", page, this, consumedPages.isEmpty());
+            }
             return info != null && info.isDone();
          }
       }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-4854
Upstream issue: https://issues.apache.org/jira/browse/ARTEMIS-558
Upstream PR: https://github.com/apache/activemq-artemis/pull/569
