### PR TITLE
ARTEMIS-651 Typo in word "topology" in class ServerLocatorImpl

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -530,7 +530,7 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
          // if the topologyArray is null, we will use the initialConnectors
          if (usedTopology != null) {
             if (logger.isTraceEnabled()) {
-               logger.trace("Selecting connector from toplogy.");
+               logger.trace("Selecting connector from topology.");
             }
             int pos = loadBalancingPolicy.select(usedTopology.length);
             Pair<TransportConfiguration, TransportConfiguration> pair = usedTopology[pos];
@@ -1744,7 +1744,7 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return clone;
    }
 
-   public boolean isReceivedToplogy() {
+   public boolean isReceivedTopology() {
       return receivedTopology;
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQClusteredTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ActiveMQClusteredTest.java
@@ -145,7 +145,7 @@ public class ActiveMQClusteredTest extends ActiveMQRAClusteredTestBase {
          long timeout = 10000;
          long now = System.currentTimeMillis();
 
-         while (!((ServerLocatorImpl)cf1.getServerLocator()).isReceivedToplogy()) {
+         while (!((ServerLocatorImpl)cf1.getServerLocator()).isReceivedTopology()) {
             Thread.sleep(50);
          }
 


### PR DESCRIPTION
(cherry picked from commit c9dfbad69c0a4022310ffdbbe3d8fdcf39e40b4c)

https://issues.jboss.org/browse/JBEAP-5826
