### PR TITLE
ARTEMIS-652 Incorrect null check in ActiveMQActivationSpec#toString f…

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
@@ -761,7 +761,7 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
       StringBuffer buffer = new StringBuffer();
       buffer.append(ActiveMQActivationSpec.class.getName()).append('(');
       buffer.append("ra=").append(ra);
-      if (messageSelector != null) {
+      if (connectionFactoryLookup != null) {
          buffer.append(" connectionFactoryLookup=").append(connectionFactoryLookup);
       }
       buffer.append(" destination=").append(destination);


### PR DESCRIPTION
…or attribute connectionFactoryLookup

Changed null check to check correct attribute

(cherry picked from commit d281eb5140cda86f7338be54880f307a7e8c82aa)

https://issues.jboss.org/browse/JBEAP-5825
