### PR TITLE
NPE in openwire protocol

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQSession.java
@@ -194,6 +194,11 @@ public class AMQSession implements SessionCallback {
    @Override
    public boolean hasCredits(ServerConsumer consumerID) {
       AMQConsumer amqConsumer = consumers.get(consumerID.getID());
+      if (amqConsumer == null) {
+         // ServerConsumer could be initialized already,
+         // but AMQConsumer could be not added to consumers map yet
+         return false;
+      }
       return amqConsumer.hasCredits();
    }
 


### PR DESCRIPTION
I have recently found bug in OpenWire protocol implementation. NPE is thrown when client (consumer) connects to server using OpenWire protocol and there are already messages in the queue. **ServerConsumer** is associated with queue after executing _**AMQSession.java:140**_, but it's not registered in **AMQSession::products** yet, **ServerConsumerImpl::handle()** calls **hasCredits()** method before checking **started** flag causing NPE.
This issue is not present in Artemis 1.3.0, so I didn't post a bug there. Despite my best efforts, I cannot understant relations between ActiveMQ Artemis and JBoss ActiveMQ Artemis, so I just create a pull request,
