### PR TITLE
[JBEAP-4721] In rare circumstances MessageProducer can send a message…

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerImpl.java
@@ -256,7 +256,6 @@ public class ClientProducerImpl implements ClientProducerInternal {
          }
          else {
             sendRegularMessage(msgI, sendBlocking, theCredits, handler);
-            session.checkDefaultAddress(sendingAddress);
          }
       }
       finally {
@@ -280,6 +279,7 @@ public class ClientProducerImpl implements ClientProducerInternal {
 
       theCredits.acquireCredits(creditSize);
 
+      session.checkDefaultAddress(address);
       sessionContext.sendFullMessage(msgI, sendBlocking, handler, address);
    }
 


### PR DESCRIPTION
… to wrong queue.
JIRA: https://issues.jboss.org/browse/JBEAP-4721

backport from : https://github.com/hornetq/hornetq/commit/f1b3aa4f32541151bdc9e33659f625da37bd1541
