### PR TITLE
ARTEMIS-709 Possible NPE on UUIDGenerator.getAllNetworkInterfaces()

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/UUIDGenerator.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/UUIDGenerator.java
@@ -258,7 +258,11 @@ public final class UUIDGenerator {
       try {
          networkInterfaces = NetworkInterface.getNetworkInterfaces();
 
-         List<NetworkInterface> ifaces = new ArrayList<NetworkInterface>();
+         if (networkInterfaces == null) {
+            return Collections.emptyList();
+         }
+
+         List<NetworkInterface> ifaces = new ArrayList<>();
          while (networkInterfaces.hasMoreElements()) {
             ifaces.add(networkInterfaces.nextElement());
          }


### PR DESCRIPTION
(cherry picked from commit d5eaccf3ba8088c9308837a2e4173320d366038c)

http://issues.jboss.org/browse/JBEAP-5829
