### PR TITLE
JBEAP-6170 messages could be sent to wrong queue

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientProducerImpl.java
@@ -255,8 +255,7 @@ public class ClientProducerImpl implements ClientProducerInternal {
             largeMessageSend(sendBlocking, msgI, theCredits, handler);
          }
          else {
-            sendRegularMessage(msgI, sendBlocking, theCredits, handler);
-            session.checkDefaultAddress(sendingAddress);
+            sendRegularMessage(sendingAddress, msgI, sendBlocking, theCredits, handler);
          }
       }
       finally {
@@ -264,7 +263,8 @@ public class ClientProducerImpl implements ClientProducerInternal {
       }
    }
 
-   private void sendRegularMessage(final MessageInternal msgI,
+   private void sendRegularMessage(final SimpleString sendingAddress,
+                                   final MessageInternal msgI,
                                    final boolean sendBlocking,
                                    final ClientProducerCredits theCredits,
                                    final SendAcknowledgementHandler handler) throws ActiveMQException {
@@ -279,6 +279,8 @@ public class ClientProducerImpl implements ClientProducerInternal {
       int creditSize = sessionContext.getCreditsOnSendingFull(msgI);
 
       theCredits.acquireCredits(creditSize);
+
+      session.checkDefaultAddress(sendingAddress);
 
       sessionContext.sendFullMessage(msgI, sendBlocking, handler, address);
    }
@@ -479,7 +481,7 @@ public class ClientProducerImpl implements ClientProducerInternal {
                msgI.putLongProperty(Message.HDR_LARGE_BODY_SIZE, deflaterReader.getTotalSize());
 
                msgI.getBodyBuffer().writeBytes(buff, 0, pos);
-               sendRegularMessage(msgI, sendBlocking, credits, handler);
+               sendRegularMessage(msgI.getAddress(), msgI, sendBlocking, credits, handler);
                return;
             }
             else {


### PR DESCRIPTION
In rare circumstances MessageProducer can send a message
to wrong queue

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-715
         https://issues.jboss.org/browse/JBEAP-6170

(cherry picked from commit 62f90eaf813c2f374e60bced7c26c6033c5dbeea)
