### PR TITLE
[JBEAP-7411] ARTEMIS-859 : Enable BACKLOG_PROP_NAME

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -250,6 +250,7 @@ public class TransportConstants {
       allowableAcceptorKeys.add(TransportConstants.CONNECTIONS_ALLOWED);
       allowableAcceptorKeys.add(ActiveMQDefaultConfiguration.getPropMaskPassword());
       allowableAcceptorKeys.add(ActiveMQDefaultConfiguration.getPropPasswordCodec());
+      allowableAcceptorKeys.add(TransportConstants.BACKLOG_PROP_NAME);
 
       ALLOWABLE_ACCEPTOR_KEYS = Collections.unmodifiableSet(allowableAcceptorKeys);
 


### PR DESCRIPTION
(7.1.0) Artemis backlog property not in allowed properties
https://issues.jboss.org/browse/JBEAP-7411

upstream: https://issues.apache.org/jira/browse/ARTEMIS-859
https://github.com/apache/activemq-artemis/pull/893