### PR TITLE
ARTEMIS-962 Fix CME when parsing system properties

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -302,22 +302,23 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    @Override
    public Configuration parseSystemProperties(Properties properties) throws Exception {
+      synchronized (properties) {
+         Map<String, Object> beanProperties = new HashMap<>();
 
-      Map<String, Object> beanProperties = new HashMap<>();
-
-      for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-         if (entry.getKey().toString().startsWith(systemPropertyPrefix)) {
-            String key = entry.getKey().toString().substring(systemPropertyPrefix.length());
-            logger.debug("Setting up config, " + key + "=" + entry.getValue());
-            beanProperties.put(key, entry.getValue());
+         for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            if (entry.getKey().toString().startsWith(systemPropertyPrefix)) {
+               String key = entry.getKey().toString().substring(systemPropertyPrefix.length());
+               logger.debug("Setting up config, " + key + "=" + entry.getValue());
+               beanProperties.put(key, entry.getValue());
+            }
          }
-      }
 
-      if (!beanProperties.isEmpty()) {
-         BeanSupport.setData(this, beanProperties);
-      }
+         if (!beanProperties.isEmpty()) {
+            BeanSupport.setData(this, beanProperties);
+         }
 
-      return this;
+         return this;
+      }
    }
 
    @Override


### PR DESCRIPTION
Add synchronized block against the properties before iterating on them.

Upstream JIRA: https://issues.apache.org/jira/browse/ARTEMIS-926

JIRA: https://issues.jboss.org/browse/JBEAP-8157

(cherry picked from commit 5ae47e8c3c4cd17ca6abc75e72be0338b0ceaf96)