### PR TITLE
JBEAP-6196 ARTEMIS-734 Message expired while being moved on the clust…

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -1111,13 +1111,17 @@ public class QueueImpl implements Queue {
       }
    }
 
-   @Override
    public void expire(final MessageReference ref) throws Exception {
-      if (expiryAddress != null) {
+      SimpleString messageExpiryAddress = expiryAddressFromMessageAddress(ref);
+      if (messageExpiryAddress == null) {
+         messageExpiryAddress = expiryAddressFromAddressSettings(ref);
+      }
+
+      if (messageExpiryAddress != null) {
          if (logger.isTraceEnabled()) {
-            logger.trace("moving expired reference " + ref + " to address = " + expiryAddress + " from queue=" + this.getName());
+            logger.trace("moving expired reference " + ref + " to address = " + messageExpiryAddress + " from queue=" + this.getName());
          }
-         move(null, expiryAddress, ref, false, AckReason.EXPIRED);
+         move(null, messageExpiryAddress, ref, false, AckReason.EXPIRED);
       }
       else {
          if (logger.isTraceEnabled()) {
@@ -1126,6 +1130,40 @@ public class QueueImpl implements Queue {
          acknowledge(ref, AckReason.EXPIRED);
       }
    }
+
+   private SimpleString expiryAddressFromMessageAddress(MessageReference ref) {
+      SimpleString messageAddress = extractAddress(ref.getMessage());
+      SimpleString expiryAddress = null;
+
+      if (messageAddress == null || messageAddress.equals(getAddress())) {
+         expiryAddress = getExpiryAddress();
+      }
+
+      return expiryAddress;
+   }
+
+   private SimpleString expiryAddressFromAddressSettings(MessageReference ref) {
+      SimpleString messageAddress = extractAddress(ref.getMessage());
+      SimpleString expiryAddress = null;
+
+      if (messageAddress != null) {
+         AddressSettings addressSettings = addressSettingsRepository.getMatch(messageAddress.toString());
+
+         expiryAddress = addressSettings.getExpiryAddress();
+      }
+
+      return expiryAddress;
+   }
+
+   private SimpleString extractAddress(ServerMessage message) {
+      if (message.containsProperty(Message.HDR_ORIG_MESSAGE_ID)) {
+         return message.getSimpleStringProperty(Message.HDR_ORIGINAL_ADDRESS);
+      }
+      else {
+         return message.getAddress();
+      }
+   }
+
 
    @Override
    public SimpleString getExpiryAddress() {


### PR DESCRIPTION
…er bridge does not follow the address setting configuration.

(cherry picked from commit 2509eeb818078627838ee2cd5b828fc98c514dfa)

This is for 7.0.z issue https://issues.jboss.org/browse/JBEAP-6196

The previous https://github.com/rh-messaging/jboss-activemq-artemis/pull/120 is incomplete. See History for QueueImpl.java at https://github.com/rh-messaging/jboss-activemq-artemis/commits/jboss-1.1.0-x/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java Commits on Sep 28, 2016. The actual commit content https://github.com/rh-messaging/jboss-activemq-artemis/commit/e5696ea8bda3dd313629b7c86147baa693355af2 is different than https://github.com/rh-messaging/jboss-activemq-artemis/commit/2509eeb818078627838ee2cd5b828fc98c514dfa from jboss-1.5.3-x branch.
It seems that the real commit has been changed for some reason in cherry-pick.