### PR TITLE
JBEAP-5981 ARTEMIS-538 (7.0.z) [Artemis Testsuite] JMSFailoverListenerTest#testManualFailover fails

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ActiveMQThreadFactory.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ActiveMQThreadFactory.java
@@ -87,4 +87,9 @@ public final class ActiveMQThreadFactory implements ThreadFactory {
       return t;
    }
 
+   public static ActiveMQThreadFactory defaultThreadFactory() {
+      String callerClassName = Thread.currentThread().getStackTrace()[2].getClassName();
+      return new ActiveMQThreadFactory(callerClassName, false, null);
+   }
+
 }

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -35,6 +35,8 @@ import javax.jms.TopicSession;
 import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
@@ -48,6 +50,7 @@ import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants;
 import org.apache.activemq.artemis.core.client.impl.ClientSessionInternal;
 import org.apache.activemq.artemis.core.version.Version;
 import org.apache.activemq.artemis.reader.MessageUtil;
+import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.apache.activemq.artemis.utils.ConcurrentHashSet;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.apache.activemq.artemis.utils.VersionLoader;
@@ -112,6 +115,8 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
    private final SessionFailureListener listener = new JMSFailureListener(this);
 
    private final FailoverEventListener failoverListener = new FailoverEventListenerImpl(this);
+
+   private final ExecutorService failoverListenerExecutor = Executors.newFixedThreadPool(1, ActiveMQThreadFactory.defaultThreadFactory());
 
    private final Version thisVersion;
 
@@ -343,6 +348,8 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
                initialSession.close();
             }
          }
+
+         failoverListenerExecutor.shutdown();
 
          closed = true;
       }
@@ -742,11 +749,12 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
                if (failoverListener != null) {
 
-                  new Thread(new Runnable() {
+                  conn.failoverListenerExecutor.execute(new Runnable() {
+                     @Override
                      public void run() {
                         failoverListener.failoverEvent(eventType);
                      }
-                  }).start();
+                  });
                }
             }
             catch (JMSException e) {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -33,6 +33,8 @@ import javax.jms.Topic;
 import javax.jms.TopicConnection;
 import javax.jms.TopicSession;
 import java.lang.ref.WeakReference;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -349,7 +351,13 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
             }
          }
 
-         failoverListenerExecutor.shutdown();
+         AccessController.doPrivileged(new PrivilegedAction() {
+            @Override
+            public Object run() {
+               failoverListenerExecutor.shutdown();
+               return null;
+            }
+         });
 
          closed = true;
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/JMSFailoverListenerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/cluster/JMSFailoverListenerTest.java
@@ -56,7 +56,6 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -312,7 +311,7 @@ public class JMSFailoverListenerTest extends ActiveMQTestBase {
 
    private static class MyFailoverListener implements FailoverEventListener {
 
-      private List<FailoverEventType> eventTypeList = Collections.synchronizedList(new ArrayList<FailoverEventType>());
+      private List<FailoverEventType> eventTypeList = new ArrayList<>();
 
       public FailoverEventType get(int element) {
          waitForElements(element + 1);


### PR DESCRIPTION
(cherry picked from commit fb9d097)
(cherry picked from commit 0df3071)

JIRA: https://issues.jboss.org/browse/JBEAP-5981
Upstream JIRA: 
https://issues.apache.org/jira/browse/ARTEMIS-538
https://issues.apache.org/jira/browse/ARTEMIS-808


defaultThreadFactory() method was taken from a622fa7443c6f051ee7ea773cded44f658946100 as cherry-pick would introduce a lot of collisions