### PR TITLE
Selectorparser fix - Possible memory leak - The size of LRUCache can grow above the maxCacheSize limit calling the put method concurrently

### DIFF
--- a/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/impl/SelectorParser.java
+++ b/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/impl/SelectorParser.java
@@ -23,12 +23,14 @@ import org.apache.activemq.artemis.selector.filter.ComparisonExpression;
 import org.apache.activemq.artemis.selector.filter.FilterException;
 import org.apache.activemq.artemis.selector.hyphenated.HyphenatedParser;
 import org.apache.activemq.artemis.selector.strict.StrictParser;
+import java.util.Map;
+import java.util.Collections;
 
 /**
  */
 public class SelectorParser {
 
-   private static final LRUCache<String, Object> cache = new LRUCache<>(100);
+   private static final Map<String, Object> cache = Collections.synchronizedMap(new LRUCache<>(100));
    private static final String CONVERT_STRING_EXPRESSIONS_PREFIX = "convert_string_expressions:";
    private static final String HYPHENATED_PROPS_PREFIX = "hyphenated_props:";
    private static final String NO_CONVERT_STRING_EXPRESSIONS_PREFIX = "no_convert_string_expressions:";


### PR DESCRIPTION
I do not know whether this is the correct way of communicating an issue or not, so pardon me in advance.

We use Artemis ActiveMQ version 1.1.0-wildfly-017 in production and recently we have encountered OOM exception in one of our server log. We recorded a HPROF dump and we could trace back the issue to LRUCache which stored more than 900.000 entries even though that the maxCacheSize is set to 100.

The LRUCahce uses LinkedHashMap which is not thread-safe. So putting new entries concurrently in the map could render removeEldestEntry ineffective because it is called after put is called (and we had put calls very close to each other in time). 

We were able to reproduce this issue and then we made this slight code change (wrapping the LRUCache into a synchronized map in SelectorParser.java). We tested the solution and we saw that the size of the map never grew above the maxCacheSize limit.

A sidenote:
I serched for issues similar to ours and came across this one: https://issues.apache.org/jira/browse/AMQ-2290 (I could not find anything else which resembled to our problem)
Therefore we implemented the exact same solution.