### PR TITLE
ARTEMIS-950 Change log level from INFO to WARN for "Invalid "host" va…

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/ActiveMQJMSServerLogger.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/ActiveMQJMSServerLogger.java
@@ -52,8 +52,8 @@ public interface ActiveMQJMSServerLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void serverCachingCommand(Object runnable);
 
-   @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 121005, value = "Invalid \"host\" value \"0.0.0.0\" detected for \"{0}\" connector. Switching to \"{1}\". If this new address is incorrect please manually configure the connector to use the proper one.",
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 122005, value = "Invalid \"host\" value \"0.0.0.0\" detected for \"{0}\" connector. Switching to \"{1}\". If this new address is incorrect please manually configure the connector to use the proper one.",
       format = Message.Format.MESSAGE_FORMAT)
    void invalidHostForConnector(String name, String newHost);
 

--- a/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/ActiveMQXARecoveryLogger.java
+++ b/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/ActiveMQXARecoveryLogger.java
@@ -56,8 +56,8 @@ public interface ActiveMQXARecoveryLogger extends BasicLogger {
       format = Message.Format.MESSAGE_FORMAT)
    void serverCachingCommand(Object runnable);
 
-   @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 121005, value = "Invalid \"host\" value \"0.0.0.0\" detected for \"{0}\" connector. Switching to \"{1}\". If this new address is incorrect please manually configure the connector to use the proper one.",
+   @LogMessage(level = Logger.Level.WARN)
+   @Message(id = 122005, value = "Invalid \"host\" value \"0.0.0.0\" detected for \"{0}\" connector. Switching to \"{1}\". If this new address is incorrect please manually configure the connector to use the proper one.",
       format = Message.Format.MESSAGE_FORMAT)
    void invalidHostForConnector(String name, String newHost);
 


### PR DESCRIPTION
…lue "0.0.0.0" detected for..." when Artemis is bound to 0.0.0.0

(cherry picked from commit 93ebbfdeaaa3f79c76d6028703c3c7b23bb3783e)
(cherry picked from commit d402f67f4e6c14072213c2a2936edb032cee751b)

https://issues.jboss.org/browse/JBEAP-8677