### PR TITLE
ARTEMIS-1233 Fix log level in logger message.

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -300,6 +300,10 @@ public interface ActiveMQServerLogger extends BasicLogger {
    @Message(id = 221050, value = "Activating Shared Store Slave", format = Message.Format.MESSAGE_FORMAT)
    void activatingSharedStoreSlave();
 
+   @LogMessage(level = Logger.Level.INFO)
+   @Message(id = 221059, value = "Deleting old data directory {0} as the max folders is set to 0", format = Message.Format.MESSAGE_FORMAT)
+   void backupDeletingData(String oldPath);
+
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222000, value = "ActiveMQServer is being finalized and has not been stopped. Please remember to stop the server before letting it go out of scope",
       format = Message.Format.MESSAGE_FORMAT)
@@ -1100,11 +1104,6 @@ public interface ActiveMQServerLogger extends BasicLogger {
       value = "Failed to activate shared store slave",
       format = Message.Format.MESSAGE_FORMAT)
    void activateSharedStoreSlaveFailed(@Cause Throwable e);
-
-   @LogMessage(level = Logger.Level.INFO)
-   @Message(id = 222190, value = "Deleting old data directory {0} as the max folders is set to 0", format = Message.Format.MESSAGE_FORMAT)
-   void backupDeletingData(String oldPath);
-
 
    @LogMessage(level = Logger.Level.WARN)
    @Message(id = 222190,


### PR DESCRIPTION
jboss-1.1.0-x branch does not compile due to duplicate message id.
It's been fixed in tag 1.1.0.wildfly-022 but not into branch jboss-1.1.0-x.
@mtaylor 