### PR TITLE
ARTEMIS-1299 support commas in RA connection parameter values

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRaUtils.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRaUtils.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.jgroups.JChannel;
 
@@ -190,7 +191,15 @@ public final class ActiveMQRaUtils {
    public static List<Map<String, Object>> parseConfig(final String config) {
       List<Map<String, Object>> result = new ArrayList<>();
 
-      String[] topElements = config.split(",");
+      /**
+       * Some configuration values can contain commas (e.g. enabledProtocols, enabledCipherSuites, etc.).
+       * To support config values with commas, the commas in the values must be escaped (e.g. "\\,") so that
+       * the commas used to separate configs for different connectors can still function as designed.
+       */
+      String commaPlaceHolder = UUID.randomUUID().toString();
+      String replaced = config.replace("\\,", commaPlaceHolder);
+
+      String[] topElements = replaced.split(",");
 
       for (String topElement : topElements) {
          HashMap<String, Object> map = new HashMap<>();
@@ -205,7 +214,8 @@ public final class ActiveMQRaUtils {
                throw new IllegalArgumentException("Invalid expression " + element + " at " + config);
             }
 
-            map.put(expression[0].trim(), expression[1].trim());
+            // put the commas back
+            map.put(expression[0].trim(), expression[1].trim().replace(commaPlaceHolder, ","));
          }
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ResourceAdapterTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/ra/ResourceAdapterTest.java
@@ -637,6 +637,23 @@ public class ResourceAdapterTest extends ActiveMQRATestBase {
       assertTrue(endpoint.released);
    }
 
+   @Test
+   public void testConnectionParameterStringParsing() throws Exception {
+      ActiveMQResourceAdapter resourceAdapter = new ActiveMQResourceAdapter();
+      resourceAdapter.setConnectionParameters("enabledProtocols=TLS1\\,TLS1.2;sslEnabled=true");
+      assertEquals(resourceAdapter.getProperties().getParsedConnectionParameters().get(0).get("enabledProtocols"), "TLS1,TLS1.2");
+      resourceAdapter.setConnectionParameters("enabledProtocols=TLS1\\,TLS1.2;sslEnabled=true,enabledProtocols=TLS1.3\\,TLS1.4\\,TLS1.5;sslEnabled=true");
+      assertEquals(resourceAdapter.getProperties().getParsedConnectionParameters().get(0).get("enabledProtocols"), "TLS1,TLS1.2");
+      assertEquals(resourceAdapter.getProperties().getParsedConnectionParameters().get(1).get("enabledProtocols"), "TLS1.3,TLS1.4,TLS1.5");
+
+      try {
+         resourceAdapter.setConnectionParameters("enabledProtocols=TLS1,TLS1.2;sslEnabled=true,enabledProtocols=TLS1,TLS1.2;sslEnabled=true");
+         fail("This should have failed");
+      } catch (Exception e) {
+         // ignore
+      }
+   }
+
    @Override
    public boolean useSecurity() {
       return false;


### PR DESCRIPTION
Backport or https://github.com/apache/activemq-artemis/pull/1423 into 1.x

https://issues.apache.org/jira/browse/ARTEMIS-1299
https://issues.jboss.org/browse/JBEAP-11765