### PR TITLE
Changing the way to interact with JGroups in the ResourceAdapter

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRaUtils.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRaUtils.java
@@ -26,7 +26,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
-import org.jgroups.JChannel;
+import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 
 /**
  * Various utility functions
@@ -226,19 +226,18 @@ public final class ActiveMQRaUtils {
 
    /**
     * Within AS7 the RA is loaded by JCA. properties can only be passed in String form. However if
-    * RA is configured using jgroups stack, we need to pass a Channel object. As is impossible with
-    * JCA, we use this method to allow a JChannel object to be located.
+    * RA is configured using jgroups stack, we need to pass a BroadcastEndpointFactory object. As is impossible with
+    * JCA, we use this method to allow a BroadcastEndpointFactory object to be located.
     */
-   public static JChannel locateJGroupsChannel(final String locatorClass, final String name) {
-      return AccessController.doPrivileged(new PrivilegedAction<JChannel>() {
+   public static BroadcastEndpointFactory locateBroadcastEndpointFactory(final String locatorClass, final String name) {
+      return AccessController.doPrivileged(new PrivilegedAction<BroadcastEndpointFactory>() {
          @Override
-         public JChannel run() {
+         public BroadcastEndpointFactory run() {
             try {
-               ClassLoader loader = Thread.currentThread().getContextClassLoader();
-               Class<?> aClass = loader.loadClass(locatorClass);
+               Class<?> aClass = getClass().getClassLoader().loadClass(locatorClass);
                Object o = aClass.newInstance();
-               Method m = aClass.getMethod("locateChannel", new Class[]{String.class});
-               return (JChannel) m.invoke(o, name);
+               Method m = aClass.getMethod("locateBroadcastEndpointFactory", new Class[]{String.class});
+               return (BroadcastEndpointFactory) m.invoke(o, name);
             } catch (Throwable e) {
                ActiveMQRALogger.LOGGER.debug(e.getMessage(), e);
                return null;

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -42,7 +42,6 @@ import java.util.regex.Pattern;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
-import org.apache.activemq.artemis.api.core.ChannelBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.JGroupsFileBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.Pair;
@@ -61,7 +60,6 @@ import org.apache.activemq.artemis.service.extensions.ServiceUtils;
 import org.apache.activemq.artemis.service.extensions.xa.recovery.XARecoveryConfig;
 import org.apache.activemq.artemis.utils.SensitiveDataCodec;
 import org.jboss.logging.Logger;
-import org.jgroups.JChannel;
 
 /**
  * The resource adapter for ActiveMQ
@@ -1825,8 +1823,7 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       String jgroupsLocatorClassName = raProperties.getJgroupsChannelLocatorClass();
       if (jgroupsLocatorClassName != null) {
          String jchannelRefName = raProperties.getJgroupsChannelRefName();
-         JChannel jchannel = ActiveMQRaUtils.locateJGroupsChannel(jgroupsLocatorClassName, jchannelRefName);
-         return new ChannelBroadcastEndpointFactory(jchannel, jgroupsChannel);
+         return ActiveMQRaUtils.locateBroadcastEndpointFactory(jgroupsLocatorClassName, jchannelRefName);
       }
 
       String jgroupsFileName = overrideProperties.getJgroupsFile() != null ? overrideProperties.getJgroupsFile() : getJgroupsFile();


### PR DESCRIPTION
Obtaining a BroadCastEndpointFactory instead of a JChannel to connect to JGroups to avoid issue and leak with JChannel lifecyle.
