### PR TITLE
[ARTEMIS-1666] List of prepared transaction details returns Object.toString() instead of Json string

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1365,7 +1365,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
          TransactionDetail detail = new JMSTransactionDetail(xid, tx, entry.getValue());
          txDetailListJson.add(detail.toJSON());
       }
-      return txDetailListJson.toString();
+      return txDetailListJson.build().toString();
    }
 
    @Override


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/ARTEMIS-1666
JBEAP Issue: https://issues.jboss.org/browse/JBEAP-14177