### PR TITLE
[ARTEMIS-1666] List of prepared transaction details returns Object.toString() instead of Json string

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1365,7 +1365,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
          TransactionDetail detail = new JMSTransactionDetail(xid, tx, entry.getValue());
          txDetailListJson.add(detail.toJSON());
       }
-      return txDetailListJson.toString();
+      return txDetailListJson.build().toString();
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControlTest.java
@@ -71,6 +71,7 @@ import org.apache.activemq.artemis.tests.integration.management.ManagementContro
 import org.apache.activemq.artemis.tests.integration.management.ManagementTestBase;
 import org.apache.activemq.artemis.tests.unit.util.InVMNamingContext;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.utils.JsonLoader;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.junit.Assert;
 import org.junit.Before;
@@ -860,7 +861,9 @@ public class JMSServerControlTest extends ManagementTestBase {
 
       ss.close();
 
-      control.listPreparedTransactionDetailsAsJSON();
+      String result = control.listPreparedTransactionDetailsAsJSON();
+
+      Assert.assertTrue("".equals(result) || (JsonUtil.readJsonArray(result) instanceof JsonArray));
    }
 
    @Test


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/ARTEMIS-1666
JBEAP Issue: https://issues.jboss.org/browse/JBEAP-14177