### PR TITLE
[JBEAP-14173] NPE on CLI operation drop-durable-subscription

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1666,6 +1666,9 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
       @Override
       public boolean delete(SimpleString queueName) throws Exception {
          Queue queue = server.locateQueue(queueName);
+         if (queue == null) {
+            return false;
+         }
          SimpleString address = queue.getAddress();
          AddressSettings settings = server.getAddressSettingsRepository().getMatch(address.toString());
          long consumerCount = queue.getConsumerCount();


### PR DESCRIPTION
EAP 7.1 Jira: https://issues.jboss.org/browse/JBEAP-14173

It affects 1.5.x only.

The issue is only the NPE in the server log, checking the NPE fixed the problem.

PR for Artemis 1.x branch: https://github.com/apache/activemq-artemis/pull/1860

Artemis Jira: https://issues.apache.org/jira/browse/ARTEMIS-1670