### PR TITLE
[ENTMQBR-650] JMS OpenWire client cannot read notifications from activemq.notifications topic

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireMessageConverter.java
@@ -94,6 +94,8 @@ public class OpenWireMessageConverter implements MessageConverter {
    private static final String AMQ_MSG_DROPPABLE = AMQ_PREFIX + "DROPPABLE";
    private static final String AMQ_MSG_COMPRESSED = AMQ_PREFIX + "COMPRESSED";
 
+   private static final String AMQ_NOTIFICATIONS_DESTINATION = "activemq.notifications";
+
    private final WireFormat marshaller;
 
    public OpenWireMessageConverter(WireFormat marshaller) {
@@ -758,7 +760,8 @@ public class OpenWireMessageConverter implements MessageConverter {
       if (props != null) {
          for (SimpleString s : props) {
             String keyStr = s.toString();
-            if (keyStr.startsWith("_AMQ") || keyStr.startsWith("__HDR_")) {
+            if ((keyStr.startsWith("_AMQ") || keyStr.startsWith("__HDR_")) &&
+                    !(actualDestination.toString().contains(AMQ_NOTIFICATIONS_DESTINATION))) {
                continue;
             }
             Object prop = coreMessage.getObjectProperty(s);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/SimpleOpenWireTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/SimpleOpenWireTest.java
@@ -31,6 +31,10 @@ import javax.jms.Session;
 import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
 import javax.jms.TextMessage;
+import javax.jms.Topic;
+import javax.jms.TopicConnection;
+import javax.jms.TopicSession;
+import javax.jms.TopicSubscriber;
 import javax.jms.XAConnection;
 import javax.jms.XASession;
 import javax.transaction.xa.XAResource;
@@ -50,6 +54,7 @@ import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.core.postoffice.PostOffice;
 import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.junit.Assert;
@@ -1190,6 +1195,27 @@ public class SimpleOpenWireTest extends BasicOpenWireTest {
          }
          if (connection2 != null) {
             connection2.close();
+         }
+      }
+   }
+
+   @Test
+   public void testNotificationProperties() throws Exception {
+      try (TopicConnection topicConnection = factory.createTopicConnection()) {
+         TopicSession topicSession = topicConnection.createTopicSession(false, Session.AUTO_ACKNOWLEDGE);
+         Topic notificationsTopic = topicSession.createTopic("activemq.notifications");
+         TopicSubscriber subscriber = topicSession.createSubscriber(notificationsTopic);
+         List<Message> receivedMessages = new ArrayList<>();
+         subscriber.setMessageListener(receivedMessages::add);
+         topicConnection.start();
+
+         Wait.waitFor(() -> receivedMessages.size() > 0);
+
+         Assert.assertTrue(receivedMessages.size() > 0);
+
+         for (Message message : receivedMessages) {
+            assertNotNull(message);
+            assertNotNull(message.getStringProperty("_AMQ_NotifType"));
          }
       }
    }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ENTMQBR-650