### PR TITLE
ARTEMIS-1876 InVMNodeManager shouldn't be used if no JDBC HA is configured

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -460,10 +460,10 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             manager = JdbcNodeManager.with(dbConf, scheduledPool, executorFactory, shutdownOnCriticalIO);
          } else if (haType == null || haType == HAPolicyConfiguration.TYPE.LIVE_ONLY) {
             if (logger.isDebugEnabled()) {
-               logger.debug("Detected no Shared Store HA options on JDBC store: will use InVMNodeManager");
+               logger.debug("Detected no Shared Store HA options on JDBC store");
             }
             //LIVE_ONLY should be the default HA option when HA isn't configured
-            manager = new InVMNodeManager(replicatingBackup);
+            manager = new FileLockNodeManager(directory, replicatingBackup, configuration.getJournalLockAcquisitionTimeout());
          } else {
             throw new IllegalArgumentException("JDBC persistence allows only Shared Store HA options");
          }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/HAPolicyConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/HAPolicyConfigurationTest.java
@@ -33,7 +33,7 @@ import org.apache.activemq.artemis.core.server.cluster.ha.SharedStoreSlavePolicy
 import org.apache.activemq.artemis.core.server.impl.Activation;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.core.server.impl.ColocatedActivation;
-import org.apache.activemq.artemis.core.server.impl.InVMNodeManager;
+import org.apache.activemq.artemis.core.server.impl.FileLockNodeManager;
 import org.apache.activemq.artemis.core.server.impl.LiveOnlyActivation;
 import org.apache.activemq.artemis.core.server.impl.SharedNothingBackupActivation;
 import org.apache.activemq.artemis.core.server.impl.SharedNothingLiveActivation;
@@ -54,7 +54,7 @@ public class HAPolicyConfigurationTest extends ActiveMQTestBase {
       assertEquals(HAPolicyConfiguration.TYPE.LIVE_ONLY, server.getConfiguration().getHAPolicyConfiguration().getType());
       try {
          server.start();
-         assertThat(server.getNodeManager(), instanceOf(InVMNodeManager.class));
+         assertThat(server.getNodeManager(), instanceOf(FileLockNodeManager.class));
       } finally {
          server.stop();
       }


### PR DESCRIPTION
(cherry picked from commit cb00f36224c968556606d1bb798d8ea1084324c9)