### PR TITLE
[JBEAP-15226] registering recovery helpers when xa connection factories are ready

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -237,8 +237,6 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
 
       tm = ServiceUtils.getTransactionManager();
 
-      recoveryManager.start(useAutoRecovery);
-
       this.ctx = ctx;
 
       if (!configured.getAndSet(true)) {
@@ -248,6 +246,8 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
             throw new ResourceAdapterInternalException("Unable to create activation", e);
          }
       }
+
+      recoveryManager.start(useAutoRecovery);
 
       ActiveMQRALogger.LOGGER.info("Resource adaptor started");
    }
@@ -269,6 +269,8 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
          }
       }
 
+      recoveryManager.stop();
+
       activations.clear();
 
       for (ActiveMQRAManagedConnectionFactory managedConnectionFactory : managedConnectionFactories) {
@@ -289,8 +291,6 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       if (recoveryActiveMQConnectionFactory != null) {
          recoveryActiveMQConnectionFactory.close();
       }
-
-      recoveryManager.stop();
 
       ActiveMQRALogger.LOGGER.raStopped();
    }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-15226

Reordering the registration of the xa recovery helpers to the transaction manager to time when xa connection factory is started.