### PR TITLE
ARTEMIS-2089 DB2 sending larger message (1MB) crashes the whole server

### DIFF
--- a/artemis-jdbc-store/src/main/resources/journal-sql.properties
+++ b/artemis-jdbc-store/src/main/resources/journal-sql.properties
@@ -86,6 +86,7 @@ max-blob-size.oracle=4294967296
 table-names-case.oracle=upper
 
 # DB2 SQL statements
+create-journal-table.db2=CREATE TABLE %s(id BIGINT,recordType SMALLINT,compactCount SMALLINT,txId BIGINT,userRecordType SMALLINT,variableSize INTEGER,record BLOB(2G),txDataSize INTEGER,txData BLOB(2G),txCheckNoRecords INTEGER,seq BIGINT NOT NULL, PRIMARY KEY(seq))
 max-blob-size.db2=2147483647
 create-file-table.db2=CREATE TABLE %s (ID BIGINT GENERATED ALWAYS AS IDENTITY (START WITH 1 INCREMENT BY 1), FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA BLOB(2G), PRIMARY KEY(ID))
 append-to-file.db2=UPDATE %s SET DATA = (DATA || ?) WHERE ID=?


### PR DESCRIPTION
It declares JDBC journal Blobs for IBM DB2 DBMS matching max-blob-size
in order to allow to store data with size > 1 MB ie the default BLOB
capacity

(cherry picked from commit ead9b007579ad83fd6c808243e4c20035d4c4b4d)

issue: https://issues.jboss.org/browse/JBEAP-15451
upstream issue: https://issues.apache.org/jira/browse/ARTEMIS-2089
upstream PR: https://github.com/apache/activemq-artemis/pull/2317

https://issues.jboss.org/browse/WFLY-11022 depends on this as well