### PR TITLE
[JBEAP-14177] List of prepared transaction details returns Object.toString() instead of Json string

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1367,7 +1367,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
          TransactionDetail detail = new JMSTransactionDetail(xid, tx, entry.getValue());
          txDetailListJson.add(detail.toJSON());
       }
-      return txDetailListJson.toString();
+      return txDetailListJson.build().toString();
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/server/management/JMSServerControlTest.java
@@ -860,7 +860,8 @@ public class JMSServerControlTest extends ManagementTestBase {
 
       ss.close();
 
-      control.listPreparedTransactionDetailsAsJSON();
+      String result = control.listPreparedTransactionDetailsAsJSON();
+      Assert.assertTrue("".equals(result) || (JsonUtil.readJsonArray(result) instanceof JsonArray));
    }
 
    @Test


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/JBEAP-14177

Upstream Jira: https://issues.apache.org/jira/browse/ARTEMIS-1666
Upstream PR: https://github.com/apache/activemq-artemis/pull/1854