### PR TITLE
ARTEMIS-1874 fix NPE setting object property

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQMessage.java
@@ -940,7 +940,7 @@ public class ActiveMQMessage implements javax.jms.Message {
       boolean result = false;
 
       if (jmsPropertyName.equals(name)) {
-         message.putStringProperty(corePropertyName, SimpleString.toSimpleString(value.toString()));
+         message.putStringProperty(corePropertyName, value == null ? null : SimpleString.toSimpleString(value.toString()));
 
          result = true;
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/MessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/MessageTest.java
@@ -26,6 +26,7 @@ import javax.jms.Session;
 import javax.jms.StreamMessage;
 
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.tests.integration.IntegrationTestLogger;
 import org.apache.activemq.artemis.tests.util.JMSTestBase;
 import org.junit.Assert;
@@ -192,6 +193,10 @@ public class MessageTest extends JMSTestBase {
       assertEquals(null, msg.getStringProperty("Test"));
 
       msg.setObjectProperty(MessageTest.propName1, null);
+
+      msg.setObjectProperty(MessageUtil.JMSXGROUPID, null);
+
+      msg.setObjectProperty(MessageUtil.JMSXUSERID, null);
 
       msg.setStringProperty(MessageTest.propName2, null);
 


### PR DESCRIPTION
Upstream Issue: https://issues.apache.org/jira/browse/ARTEMIS-1874
Issue: https://issues.jboss.org/browse/JBEAP-15516 / https://issues.jboss.org/browse/ENTMQBR-1970
Upstream PR: https://github.com/apache/activemq-artemis/pull/2336

This is just a backport of the fix into the 1.x branch. I've setup the PR just to make the backport easy for devs, if you prefer to cherry-pick this fix later on yourself, feel free to simply close this PR! (or ask me to do it).

Note that the commit is already in the 2.6.3.jbossorg-x branch : https://github.com/rh-messaging/jboss-activemq-artemis/commit/4d492bea0ee5fb00dcceca9366375cb87d32fe94