### PR TITLE
ARTEMIS-1961 track routed and unrouted messages sent to an address

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/AddressControl.java
@@ -104,6 +104,18 @@ public interface AddressControl {
    @Attribute(desc = "number of messages added to all the queues for this address")
    long getMessageCount();
 
+   /**
+    * Returns the number of messages routed to one or more bindings
+    */
+   @Attribute(desc = "number of messages routed to one or more bindings")
+   long getRoutedMessageCount();
+
+   /**
+    * Returns the number of messages not routed to any bindings
+    */
+   @Attribute(desc = "number of messages not routed to any bindings")
+   long getUnRoutedMessageCount();
+
 
    /**
     * @param headers  the message headers and properties to set. Can only

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/AddressControlImpl.java
@@ -267,6 +267,16 @@ public class AddressControlImpl extends AbstractControl implements AddressContro
       return getMessageCount(DurabilityType.ALL);
    }
 
+   @Override
+   public long getRoutedMessageCount() {
+      return addressInfo.getRoutedMessageCount();
+   }
+
+   @Override
+   public long getUnRoutedMessageCount() {
+      return addressInfo.getUnRoutedMessageCount();
+   }
+
 
    @Override
    public String sendMessage(final Map<String, String> headers,

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -812,11 +812,11 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
          throw new IllegalStateException("Message cannot be routed more than once");
       }
 
-      setPagingStore(context.getAddress(message), message);
+      final SimpleString address = context.getAddress(message);
+
+      setPagingStore(address, message);
 
       AtomicBoolean startedTX = new AtomicBoolean(false);
-
-      final SimpleString address = context.getAddress(message);
 
       applyExpiryDelay(message, address);
 
@@ -826,23 +826,24 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
 
       message.cleanupInternalProperties();
 
-      Bindings bindings = addressManager.getBindingsForRoutingAddress(context.getAddress(message));
+      Bindings bindings = addressManager.getBindingsForRoutingAddress(address);
 
-      // TODO auto-create queues here?
-      // first check for the auto-queue creation thing
-      if (bindings == null) {
-         // There is no queue with this address, we will check if it needs to be created
-         //         if (queueCreator.create(address)) {
-         // TODO: this is not working!!!!
-         // reassign bindings if it was created
-         //            bindings = addressManager.getBindingsForRoutingAddress(address);
-         //         }
-      }
+      AddressInfo addressInfo = addressManager.getAddressInfo(address);
+
       if (bindingMove != null) {
          bindingMove.route(message, context);
+         if (addressInfo != null) {
+            addressInfo.incrementRoutedMessageCount();
+         }
       } else if (bindings != null) {
          bindings.route(message, context);
+         if (addressInfo != null) {
+            addressInfo.incrementRoutedMessageCount();
+         }
       } else {
+         if (addressInfo != null) {
+            addressInfo.incrementUnRoutedMessageCount();
+         }
          // this is a debug and not warn because this could be a regular scenario on publish-subscribe queues (or topic subscriptions on JMS)
          if (logger.isDebugEnabled()) {
             logger.debug("Couldn't find any bindings for address=" + address + " on message=" + message);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
@@ -22,6 +22,7 @@ import org.apache.activemq.artemis.utils.PrefixUtil;
 
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 public class AddressInfo {
 
@@ -35,6 +36,14 @@ public class AddressInfo {
    private RoutingType firstSeen;
 
    private boolean internal = false;
+
+   private volatile long routedMessageCount = 0;
+
+   private static final AtomicLongFieldUpdater<AddressInfo> routedMessageCountUpdater = AtomicLongFieldUpdater.newUpdater(AddressInfo.class, "routedMessageCount");
+
+   private volatile long unRoutedMessageCount = 0;
+
+   private static final AtomicLongFieldUpdater<AddressInfo> unRoutedMessageCountUpdater = AtomicLongFieldUpdater.newUpdater(AddressInfo.class, "unRoutedMessageCount");
 
    public AddressInfo(SimpleString name) {
       this(name, EnumSet.noneOf(RoutingType.class));
@@ -153,6 +162,22 @@ public class AddressInfo {
          }
       }
       return this;
+   }
+
+   public long incrementRoutedMessageCount() {
+      return routedMessageCountUpdater.incrementAndGet(this);
+   }
+
+   public long incrementUnRoutedMessageCount() {
+      return unRoutedMessageCountUpdater.incrementAndGet(this);
+   }
+
+   public long getRoutedMessageCount() {
+      return routedMessageCountUpdater.get(this);
+   }
+
+   public long getUnRoutedMessageCount() {
+      return unRoutedMessageCountUpdater.get(this);
    }
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/AddressControlUsingCoreTest.java
@@ -104,6 +104,16 @@ public class AddressControlUsingCoreTest extends AddressControlTest {
          }
 
          @Override
+         public long getRoutedMessageCount() {
+            return (long) proxy.retrieveAttributeValue("routedMessageCount");
+         }
+
+         @Override
+         public long getUnRoutedMessageCount() {
+            return (long) proxy.retrieveAttributeValue("unRoutedMessageCount");
+         }
+
+         @Override
          public String sendMessage(Map<String, String> headers,
                                    int type,
                                    String body,


### PR DESCRIPTION
(cherry picked from commit 9c62531c2fe000a3c07feba073332a6829463fb3)
https://issues.jboss.org/browse/JBEAP-15544
upstream issue: https://issues.apache.org/jira/browse/ARTEMIS-1961
upstream PR: https://github.com/apache/activemq-artemis/pull/2172