### PR TITLE
[JBEAP-16018] Fixing PagingStore leak on temporary queues

### DIFF
--- a/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
+++ b/artemis-jms-server/src/main/java/org/apache/activemq/artemis/jms/server/impl/JMSServerManagerImpl.java
@@ -1736,6 +1736,7 @@ public class JMSServerManagerImpl implements JMSServerManager, ActivateCallback 
                }
             }
          }
+         server.getPagingManager().deletePageStore(address);
       }
    }
 

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
@@ -185,6 +185,31 @@ public class TemporaryDestinationTest extends JMSTestCase {
    }
 
    @Test
+   public void testTemporaryQueueDeleteRemovesPageStore() throws Exception {
+      Connection conn = null;
+
+      try {
+         conn = createConnection();
+
+         Session producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         int base = servers.get(0).getActiveMQServer().getPagingManager().getStoreNames().length;
+
+         TemporaryQueue tempQueue = producerSession.createTemporaryQueue();
+
+         tempQueue.delete();
+
+         ProxyAssertSupport.assertEquals(base, servers.get(0).getActiveMQServer().getPagingManager().getStoreNames().length);
+
+         producerSession.close();
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
    public void testTemporaryTopicDeleteWithConsumer() throws Exception {
       Connection conn = null;
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-16018

The problem is fixed in 2.6.3 branch via https://github.com/rh-messaging/jboss-activemq-artemis/commit/b73828a0f4be333a0b9a6552db3778f4224f0089 but there were other changes involved eg. removing JMSServerManagerImpl.JMSPostQueueDeletionCallback, so adjusting the port to 1.5.5 code