### PR TITLE
[BEAP-16034] Core JMS client leaks temporary destination names

### DIFF
--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -537,6 +537,7 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    public void removeTemporaryQueue(final SimpleString queueAddress) {
       tempQueues.remove(queueAddress);
+      knownDestinations.remove(queueAddress);
    }
 
    public void addKnownDestination(final SimpleString address) {

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/TemporaryDestinationTest.java
@@ -27,6 +27,8 @@ import javax.jms.TemporaryTopic;
 import javax.jms.TextMessage;
 import javax.naming.NamingException;
 
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnection;
 import org.apache.activemq.artemis.jms.tests.util.ProxyAssertSupport;
 import org.junit.Test;
 
@@ -119,6 +121,51 @@ public class TemporaryDestinationTest extends JMSTestCase {
          ProxyAssertSupport.assertNotNull(m2);
 
          ProxyAssertSupport.assertEquals(messageText, m2.getText());
+      } finally {
+         if (conn != null) {
+            conn.close();
+         }
+      }
+   }
+
+   @Test
+   public void testTemporaryQueueLeak() throws Exception {
+      ActiveMQConnection conn = null;
+
+      try {
+         conn = (ActiveMQConnection) createConnection();
+
+         Session producerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         Session consumerSession = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+         TemporaryQueue tempQueue = producerSession.createTemporaryQueue();
+
+         MessageProducer producer = producerSession.createProducer(tempQueue);
+
+         MessageConsumer consumer = consumerSession.createConsumer(tempQueue);
+
+         conn.start();
+
+         final String messageText = "This is a message";
+
+         Message m = producerSession.createTextMessage(messageText);
+
+         producer.send(m);
+
+         TextMessage m2 = (TextMessage) consumer.receive(2000);
+
+         ProxyAssertSupport.assertNotNull(m2);
+
+         ProxyAssertSupport.assertEquals(messageText, m2.getText());
+
+         consumer.close();
+
+         tempQueue.delete();
+
+         ProxyAssertSupport.assertFalse(conn.containsKnownDestination(SimpleString.toSimpleString(tempQueue.getQueueName())));
+
+         ProxyAssertSupport.assertFalse(conn.containsTemporaryQueue(SimpleString.toSimpleString(tempQueue.getQueueName())));
       } finally {
          if (conn != null) {
             conn.close();


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-16034
Upstream Issue: https://issues.jboss.org/browse/ENTMQBR-2190 , https://issues.apache.org/jira/browse/ARTEMIS-2190
Upstream PR: https://github.com/apache/activemq-artemis/pull/2450